### PR TITLE
Fix typo in chain_id conversion

### DIFF
--- a/crates/paymaster-starknet/src/network.rs
+++ b/crates/paymaster-starknet/src/network.rs
@@ -52,7 +52,7 @@ impl ChainID {
             "SN_SEPOLIA" => Ok(Self::Sepolia),
             "mainnet" => Ok(Self::Mainnet),
             "Mainnet" => Ok(Self::Mainnet),
-            "SN_MAINMET" => Ok(Self::Mainnet),
+            "SN_MAINNET" => Ok(Self::Mainnet),
             "main" => Ok(Self::Mainnet),
             "MAIN" => Ok(Self::Mainnet),
             _ => Err(Error::TypedDataDecoding(format!("invalid domain {}", s))),


### PR DESCRIPTION
Fixing an issue where the CLI fails if `SN_MAINNET` is used as chain_id