### PR TITLE
🔍 Improve diagnostic logging for intermittent execution failures

### DIFF
--- a/crates/paymaster-execution/src/execution/execute.rs
+++ b/crates/paymaster-execution/src/execution/execute.rs
@@ -151,11 +151,17 @@ impl ExecutableTransaction {
     pub async fn estimate_sponsored_transaction(self, client: &Client, sponsor_metadata: Vec<Felt>) -> Result<EstimatedExecutableTransaction, Error> {
         let calls = self.build_sponsored_calls(sponsor_metadata);
 
-        let estimated_calls = client.estimate(&calls, self.parameters.tip()).await?;
+        let estimated_calls = client.estimate(&calls, self.parameters.tip()).await.map_err(|e| {
+            tracing::warn!(error = %e, "Sponsored transaction estimation failed");
+            e
+        })?;
         let fee_estimate = estimated_calls.estimate();
 
         // We recompute the real estimate fee. Validation step is not included in the fee estimate
-        let paid_fee_in_strk = self.compute_paid_fee(client, Felt::from(fee_estimate.overall_fee)).await?;
+        let paid_fee_in_strk = self.compute_paid_fee(client, Felt::from(fee_estimate.overall_fee)).await.map_err(|e| {
+            tracing::warn!(error = %e, overall_fee = %fee_estimate.overall_fee, "Sponsored transaction fee computation failed");
+            e
+        })?;
         let final_fee_estimate = fee_estimate.update_overall_fee(paid_fee_in_strk);
 
         let estimated_final_calls = calls.with_estimate(final_fee_estimate);
@@ -172,10 +178,16 @@ impl ExecutableTransaction {
 
         let calls = self.build_calls(transfer);
 
-        let estimated_calls = client.estimate(&calls, self.parameters.tip()).await?;
+        let estimated_calls = client.estimate(&calls, self.parameters.tip()).await.map_err(|e| {
+            tracing::warn!(error = %e, "Transaction estimation failed");
+            e
+        })?;
         let fee_estimate = estimated_calls.estimate();
 
-        let paid_fee_in_strk = self.compute_paid_fee(client, Felt::from(fee_estimate.overall_fee)).await?;
+        let paid_fee_in_strk = self.compute_paid_fee(client, Felt::from(fee_estimate.overall_fee)).await.map_err(|e| {
+            tracing::warn!(error = %e, overall_fee = %fee_estimate.overall_fee, "Transaction fee computation failed");
+            e
+        })?;
         let final_fee_estimate = fee_estimate.update_overall_fee(paid_fee_in_strk);
 
         let token_price = client.price.fetch_token(transfer.token()).await?;

--- a/crates/paymaster-execution/src/execution/execute.rs
+++ b/crates/paymaster-execution/src/execution/execute.rs
@@ -158,10 +158,13 @@ impl ExecutableTransaction {
         let fee_estimate = estimated_calls.estimate();
 
         // We recompute the real estimate fee. Validation step is not included in the fee estimate
-        let paid_fee_in_strk = self.compute_paid_fee(client, Felt::from(fee_estimate.overall_fee)).await.map_err(|e| {
-            tracing::warn!(error = %e, overall_fee = %fee_estimate.overall_fee, "Sponsored transaction fee computation failed");
-            e
-        })?;
+        let paid_fee_in_strk = self
+            .compute_paid_fee(client, Felt::from(fee_estimate.overall_fee))
+            .await
+            .map_err(|e| {
+                tracing::warn!(error = %e, overall_fee = %fee_estimate.overall_fee, "Sponsored transaction fee computation failed");
+                e
+            })?;
         let final_fee_estimate = fee_estimate.update_overall_fee(paid_fee_in_strk);
 
         let estimated_final_calls = calls.with_estimate(final_fee_estimate);
@@ -184,10 +187,13 @@ impl ExecutableTransaction {
         })?;
         let fee_estimate = estimated_calls.estimate();
 
-        let paid_fee_in_strk = self.compute_paid_fee(client, Felt::from(fee_estimate.overall_fee)).await.map_err(|e| {
-            tracing::warn!(error = %e, overall_fee = %fee_estimate.overall_fee, "Transaction fee computation failed");
-            e
-        })?;
+        let paid_fee_in_strk = self
+            .compute_paid_fee(client, Felt::from(fee_estimate.overall_fee))
+            .await
+            .map_err(|e| {
+                tracing::warn!(error = %e, overall_fee = %fee_estimate.overall_fee, "Transaction fee computation failed");
+                e
+            })?;
         let final_fee_estimate = fee_estimate.update_overall_fee(paid_fee_in_strk);
 
         let token_price = client.price.fetch_token(transfer.token()).await?;

--- a/crates/paymaster-execution/src/execution/fee/overhead.rs
+++ b/crates/paymaster-execution/src/execution/fee/overhead.rs
@@ -49,8 +49,11 @@ impl ValidationGasOverhead {
 
         match client.call(&call).await {
             Ok(response) if response.len() > 4 => Ok(Self::braavos()),
-            Ok(_) | Err(paymaster_starknet::Error::ContractNotFound) | Err(paymaster_starknet::Error::Contract(_)) => Ok(Self::none()),
-            Err(_) => Ok(Self::none()),
+            Ok(_) => Ok(Self::none()),
+            Err(e) => {
+                tracing::debug!(user = %user.to_fixed_hex_string(), error = %e, "get_signers failed (expected for non-Braavos)");
+                Ok(Self::none())
+            }
         }
     }
 }

--- a/crates/paymaster-execution/src/execution/fee/overhead.rs
+++ b/crates/paymaster-execution/src/execution/fee/overhead.rs
@@ -53,7 +53,7 @@ impl ValidationGasOverhead {
             Err(e) => {
                 tracing::debug!(user = %user.to_fixed_hex_string(), error = %e, "get_signers failed (expected for non-Braavos)");
                 Ok(Self::none())
-            }
+            },
         }
     }
 }

--- a/crates/paymaster-execution/src/lib.rs
+++ b/crates/paymaster-execution/src/lib.rs
@@ -137,11 +137,16 @@ impl Client {
     // Note that if the transaction fails for a differant reason than an invalid nonce, this function returns the
     // error.
     async fn execute_with_retries(&self, relayer: &mut LockedRelayer, calls: &EstimatedCalls, n_retries: usize) -> Result<InvokeTransactionResult, Error> {
-        for _ in 0..n_retries {
+        for attempt in 1..=n_retries {
             match relayer.execute(calls).await {
                 Ok(result) => return Ok(result),
-                Err(paymaster_relayer::Error::InvalidNonce) => {},
-                Err(e) => return Err(Error::Execution(e.to_string())),
+                Err(paymaster_relayer::Error::InvalidNonce) => {
+                    tracing::warn!(attempt, n_retries, relayer = %relayer.address().to_fixed_hex_string(), "Invalid nonce, retrying");
+                },
+                Err(e) => {
+                    tracing::warn!(attempt, relayer = %relayer.address().to_fixed_hex_string(), error = %e, "Execution failed (non-retryable)");
+                    return Err(Error::Execution(e.to_string()));
+                }
             }
         }
 

--- a/crates/paymaster-execution/src/lib.rs
+++ b/crates/paymaster-execution/src/lib.rs
@@ -146,7 +146,7 @@ impl Client {
                 Err(e) => {
                     tracing::warn!(attempt, relayer = %relayer.address().to_fixed_hex_string(), error = %e, "Execution failed (non-retryable)");
                     return Err(Error::Execution(e.to_string()));
-                }
+                },
             }
         }
 

--- a/crates/paymaster-relayer/src/relayer.rs
+++ b/crates/paymaster-relayer/src/relayer.rs
@@ -124,6 +124,12 @@ impl LockedRelayer {
                 Err(Error::InvalidNonce)
             },
             Err(e) => {
+                warn!(
+                    relayer = %self.relayer.address().to_fixed_hex_string(),
+                    nonce = %nonce.to_fixed_hex_string(),
+                    error = %e,
+                    "Relayer transaction execution failed"
+                );
                 metric!(counter[relayer_request_error] = 1, method = "execute", error = e.to_string());
 
                 Err(Error::Execution(e.to_string()))
@@ -140,12 +146,14 @@ impl LockedRelayer {
             return Ok(nonce);
         }
 
-        let nonce = self
-            .relayer
-            .account
-            .get_nonce()
-            .await
-            .map_err(|e| Error::Execution(e.to_string()))?;
+        let nonce = self.relayer.account.get_nonce().await.map_err(|e| {
+            warn!(
+                relayer = %self.relayer.address().to_fixed_hex_string(),
+                error = %e,
+                "Failed to fetch relayer nonce"
+            );
+            Error::Execution(e.to_string())
+        })?;
 
         self.lock.nonce = Some(nonce);
         Ok(nonce)

--- a/crates/paymaster-starknet/src/lib.rs
+++ b/crates/paymaster-starknet/src/lib.rs
@@ -253,7 +253,11 @@ impl Client {
     /// Fetch the nonce of the given `user`
     #[instrument(name = "fetch_nonce", skip(self))]
     pub async fn fetch_nonce(&self, user: ContractAddress) -> Result<Felt, Error> {
-        let (result, duration) = measure_duration!(log_if_error!(self.inner.get_nonce(BlockId::Tag(BlockTag::PreConfirmed), user).await));
+        let (result, duration) = measure_duration!(self.inner.get_nonce(BlockId::Tag(BlockTag::PreConfirmed), user).await);
+
+        if let Err(ref e) = result {
+            tracing::warn!(contract_address = %user.to_fixed_hex_string(), error = %e, "starknet_getNonce failed");
+        }
 
         metric!(histogram[starknet_rpc] = duration.as_millis(), method = "get_nonce");
         metric!(on error result => counter [ starknet_rpc_error ] = 1, method = "get_nonce");
@@ -265,7 +269,16 @@ impl Client {
     #[instrument(name = "call", skip(self))]
     pub async fn call(&self, call: &FunctionCall) -> Result<Vec<Felt>, Error> {
         let block = BlockId::Tag(BlockTag::PreConfirmed);
-        let (result, duration) = measure_duration!(log_if_error!(self.inner.call(call, block).await));
+        let (result, duration) = measure_duration!(self.inner.call(call, block).await);
+
+        if let Err(ref e) = result {
+            tracing::warn!(
+                contract_address = %call.contract_address.to_fixed_hex_string(),
+                entry_point_selector = %call.entry_point_selector.to_fixed_hex_string(),
+                error = %e,
+                "starknet_call failed"
+            );
+        }
 
         metric!(histogram[starknet_rpc] = duration.as_millis(), method = "call");
         metric!(on error result => counter [ starknet_rpc_error ] = 1, method = "call");
@@ -279,7 +292,11 @@ impl Client {
         let block = BlockId::Tag(BlockTag::PreConfirmed);
 
         // Estimate fees
-        let (result, duration) = measure_duration!(log_if_error!(self.inner.estimate_fee(transactions, vec![SkipValidate], block).await));
+        let (result, duration) = measure_duration!(self.inner.estimate_fee(transactions, vec![SkipValidate], block).await);
+
+        if let Err(ref e) = result {
+            tracing::warn!(error = %e, "starknet_estimateFee failed");
+        }
 
         metric!(histogram[starknet_rpc] = duration.as_millis(), method = "estimate_transactions");
         metric!(on error result => counter [ starknet_rpc_error ] = 1, method = "estimate_transactions");

--- a/crates/paymaster-starknet/src/transaction/version.rs
+++ b/crates/paymaster-starknet/src/transaction/version.rs
@@ -102,7 +102,7 @@ impl PaymasterVersion {
                     "supports_interface call failed"
                 );
                 Err(Error::Starknet(e.to_string()))
-            }
+            },
         }
     }
 }

--- a/crates/paymaster-starknet/src/transaction/version.rs
+++ b/crates/paymaster-starknet/src/transaction/version.rs
@@ -4,6 +4,7 @@ use paymaster_common::concurrency::ConcurrentExecutor;
 use paymaster_common::task;
 use starknet::core::types::{Felt, FunctionCall};
 use starknet::macros::selector;
+use tracing::warn;
 
 use crate::contract::ContractClass;
 use crate::{Client, Error};
@@ -93,7 +94,15 @@ impl PaymasterVersion {
 
         match response {
             Ok(value) => Ok(value.first() == Some(&Felt::ONE)),
-            Err(e) => Err(Error::Starknet(e.to_string())),
+            Err(e) => {
+                warn!(
+                    user = %user.to_fixed_hex_string(),
+                    interface_id = %interface_id.to_fixed_hex_string(),
+                    error = %e,
+                    "supports_interface call failed"
+                );
+                Err(Error::Starknet(e.to_string()))
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add structured logging at every critical step of the `executeTransaction` flow to diagnose intermittent "execution call was rejected" errors reported after the RPC upgrade
- `starknet_call` errors now log `contract_address` + `entry_point_selector` explicitly (no more guessing selectors)
- Relayer execution errors now log the relayer address, nonce used, and attempt number
- Estimation and fee computation failures are now logged before error propagation
- `get_signers` (Braavos detection) noise reduced from WARN to DEBUG

## Context
After the Starknet RPC upgrade, we're seeing intermittent failures (`EntrypointNotFound`, `execution call was rejected`, `call was rejected` on `get_nonce`) that we can't diagnose because the current logging doesn't tell us **which step** in the execution flow fails.

## Test plan
- [ ] Deploy to sepolia
- [ ] Ask Craig to reproduce the intermittent failure (4x same call)
- [ ] Verify new WARN logs show exactly where the failure occurs (estimation vs execution, which relayer, which nonce)