### PR TITLE
feat: add validation gas overhead for Shhh wallets and SNIP-163 session accounts

### DIFF
--- a/crates/paymaster-execution/src/execution/fee/overhead.rs
+++ b/crates/paymaster-execution/src/execution/fee/overhead.rs
@@ -25,7 +25,7 @@ impl Mul<ValidationGasOverhead> for BlockGasPrice {
 }
 
 impl ValidationGasOverhead {
-    /// No additional gos
+    /// No additional gas
     fn none() -> Self {
         Self::default()
     }
@@ -39,15 +39,102 @@ impl ValidationGasOverhead {
         }
     }
 
-    /// Returns the overhead approximation given the [`user`] address
+    /// Additional cost for Shhh Ed25519 wallet — Garaga v1.0.1 on-chain EdDSA verification.
+    /// Enables Solana (Phantom) users to operate Starknet smart accounts with their existing wallet.
+    /// Breakdown: Garaga MSM + EdDSA (~33M) + bytes_to_hex_ascii loop (~5M) +
+    /// OE byte encoding + Poseidon (~3M) + Serde deserialization of ~100 felt252 hints (~5M) +
+    /// message byte comparison loop 372 iterations (~2M) + storage reads/writes (~2M).
+    /// See: https://github.com/haycarlitos/shhh-wallet-cairo
+    fn shhh_ed25519() -> Self {
+        Self {
+            l1_gas: Felt::ZERO,
+            l1_data_gas: Felt::ZERO,
+            l2_gas: felt!("0x04c4b400"), // ~80M L2 gas
+        }
+    }
+
+    /// Additional cost for Shhh EVM wallet — native secp256k1 verify_eth_signature syscall.
+    /// Enables MetaMask/EVM users to operate Starknet smart accounts.
+    /// Breakdown: keccak256 syscall for EIP-191 hash (~5M) + verify_eth_signature/ecrecover (~8M) +
+    /// OE byte encoding + Poseidon (~3M) + ByteArray construction loops (~2M) +
+    /// storage reads/writes (~2M).
+    fn shhh_evm() -> Self {
+        Self {
+            l1_gas: Felt::ZERO,
+            l1_data_gas: Felt::ZERO,
+            l2_gas: felt!("0x01312D00"), // ~20M L2 gas
+        }
+    }
+
+    /// Additional cost for SNIP-163 session accounts (Chipi Pay reference implementation).
+    /// Session key validation involves dual-hash SNIP-12 computation (worst case: two full
+    /// Poseidon hashes + two ECDSA verifications), session data storage reads,
+    /// entrypoint whitelist iteration, call consumption writes, and spending policy checks.
+    /// See: https://github.com/starknet-io/SNIPs/pull/163
+    /// See: https://github.com/chipi-pay/sessions-smart-contract
+    fn chipi_sessions() -> Self {
+        Self {
+            l1_gas: Felt::ZERO,
+            l1_data_gas: Felt::ZERO,
+            l2_gas: felt!("0x01312D00"), // ~20M L2 gas
+        }
+    }
+
+    /// Returns the overhead approximation given the [`user`] address.
+    ///
+    /// Detection order: Shhh Ed25519 → Shhh EVM → SNIP-163 Sessions → Braavos → none.
+    /// Each check calls a unique entrypoint on the account; results are cached upstream.
     pub async fn fetch(client: &Client, user: ContractAddress) -> Result<Self, Error> {
-        let call = FunctionCall {
+        // 1. Shhh Ed25519 wallet: get_owner() returns u256 (exactly 2 felts)
+        let shhh_call = FunctionCall {
             contract_address: user,
-            entry_point_selector: selector!("get_signers"), // This endpoint is specific to Braavos
+            entry_point_selector: selector!("get_owner"),
             calldata: vec![],
         };
+        match client.call(&shhh_call).await {
+            Ok(response) if response.len() == 2 => return Ok(Self::shhh_ed25519()),
+            Ok(_) => {},
+            Err(e) => {
+                tracing::debug!(user = %user.to_fixed_hex_string(), error = %e, "get_owner failed (expected for non-Shhh Ed25519)");
+            },
+        }
 
-        match client.call(&call).await {
+        // 2. Shhh EVM wallet: get_eth_address() returns EthAddress (exactly 1 felt)
+        let evm_call = FunctionCall {
+            contract_address: user,
+            entry_point_selector: selector!("get_eth_address"),
+            calldata: vec![],
+        };
+        match client.call(&evm_call).await {
+            Ok(response) if response.len() == 1 => return Ok(Self::shhh_evm()),
+            Ok(_) => {},
+            Err(e) => {
+                tracing::debug!(user = %user.to_fixed_hex_string(), error = %e, "get_eth_address failed (expected for non-Shhh EVM)");
+            },
+        }
+
+        // 3. SNIP-163 session accounts: supports_interface(SESSION_KEY_MANAGER_ID)
+        //    Interface ID from SNIP-163 Part G: XOR of starknetKeccak of ISessionKeyManager selectors
+        let session_call = FunctionCall {
+            contract_address: user,
+            entry_point_selector: selector!("supports_interface"),
+            calldata: vec![felt!("0x037ab4f01106526662a612eaa2926df2aa314c4144b964f183805880bbcfa55d")],
+        };
+        match client.call(&session_call).await {
+            Ok(response) if response.first() == Some(&Felt::ONE) => return Ok(Self::chipi_sessions()),
+            Ok(_) => {},
+            Err(e) => {
+                tracing::debug!(user = %user.to_fixed_hex_string(), error = %e, "supports_interface(SESSION_KEY_MANAGER) failed");
+            },
+        }
+
+        // 4. Braavos MFA (existing)
+        let braavos_call = FunctionCall {
+            contract_address: user,
+            entry_point_selector: selector!("get_signers"),
+            calldata: vec![],
+        };
+        match client.call(&braavos_call).await {
             Ok(response) if response.len() > 4 => Ok(Self::braavos()),
             Ok(_) => Ok(Self::none()),
             Err(e) => {
@@ -55,5 +142,61 @@ impl ValidationGasOverhead {
                 Ok(Self::none())
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_none_overhead_is_zero() {
+        let overhead = ValidationGasOverhead::none();
+        assert_eq!(overhead.l1_gas, Felt::ZERO);
+        assert_eq!(overhead.l1_data_gas, Felt::ZERO);
+        assert_eq!(overhead.l2_gas, Felt::ZERO);
+    }
+
+    #[test]
+    fn test_braavos_overhead() {
+        let overhead = ValidationGasOverhead::braavos();
+        assert_eq!(overhead.l2_gas, felt!("0x02c7ab80"));
+        assert_eq!(overhead.l1_gas, Felt::ZERO);
+    }
+
+    #[test]
+    fn test_shhh_ed25519_overhead() {
+        let overhead = ValidationGasOverhead::shhh_ed25519();
+        assert_eq!(overhead.l2_gas, felt!("0x04c4b400")); // ~80M
+        assert_eq!(overhead.l1_gas, Felt::ZERO);
+        assert_eq!(overhead.l1_data_gas, Felt::ZERO);
+    }
+
+    #[test]
+    fn test_shhh_evm_overhead() {
+        let overhead = ValidationGasOverhead::shhh_evm();
+        assert_eq!(overhead.l2_gas, felt!("0x01312D00")); // ~20M
+        assert_eq!(overhead.l1_gas, Felt::ZERO);
+    }
+
+    #[test]
+    fn test_chipi_sessions_overhead() {
+        let overhead = ValidationGasOverhead::chipi_sessions();
+        assert_eq!(overhead.l2_gas, felt!("0x01312D00")); // ~20M
+        assert_eq!(overhead.l1_gas, Felt::ZERO);
+    }
+
+    #[test]
+    fn test_overhead_ordering() {
+        // Ed25519 has highest overhead (Garaga MSM), all others are lower
+        let ed25519 = ValidationGasOverhead::shhh_ed25519();
+        let evm = ValidationGasOverhead::shhh_evm();
+        let sessions = ValidationGasOverhead::chipi_sessions();
+        let braavos = ValidationGasOverhead::braavos();
+        let none = ValidationGasOverhead::none();
+        assert!(ed25519.l2_gas > braavos.l2_gas);
+        assert!(braavos.l2_gas > sessions.l2_gas);
+        assert!(sessions.l2_gas >= evm.l2_gas);
+        assert!(evm.l2_gas > none.l2_gas);
     }
 }


### PR DESCRIPTION
## Problem

`starknet_estimateFee` uses `SKIP_VALIDATE`, so accounts with expensive validation logic get underestimated gas limits. This is the same issue solved for Braavos MFA accounts in the existing `braavos()` overhead.

Three new account types need overhead support:

1. **Shhh Ed25519 wallet** — uses Garaga v1.0.1 for on-chain Ed25519 signature verification (~33M L2 gas), enabling Solana (Phantom) users to operate Starknet smart accounts with their existing wallet.

2. **Shhh EVM wallet** — uses native `verify_eth_signature` syscall for secp256k1 verification, enabling MetaMask/EVM users to operate Starknet smart accounts.

3. **SNIP-163 session accounts** (Chipi Pay reference implementation) — session key validation involves dual-hash SNIP-12 computation, session data storage reads, entrypoint whitelist iteration, and call consumption writes. These add significant L2 gas beyond a standard OZ account.

## Why this matters

**Cross-chain wallet access**: Shhh wallets let users from Solana and EVM ecosystems use Starknet without managing Starknet-native keys. All operations go through `execute_from_outside_v2` (SNIP-9 V2), making paymaster gas estimation accuracy critical. Correct overhead values allow these wallets to work seamlessly with any dApp using the AVNU paymaster.

**Agentic smart wallets**: SNIP-163 (merged into starknet-io/SNIPs, [PR #163](https://github.com/starknet-io/SNIPs/pull/163)) defines the session key standard for Starknet. Session keys enable scoped, time-bounded, call-limited delegation — the primitive for AI agents, automated yield strategies, and gaming bots operating on-chain. As session-based accounts grow, accurate gas estimation ensures reliable paymaster-sponsored execution.

Supporting these account types in the paymaster helps attract liquidity to Starknet by lowering the barrier for users already holding assets on Solana or EVM chains.

## Detection

Following the existing Braavos pattern (entrypoint-based detection, cached per user address):

| Account Type | Detection Method | Response |
|---|---|---|
| Shhh Ed25519 | `get_owner()` | Exactly 2 felts (u256 halves) |
| Shhh EVM | `get_eth_address()` | Exactly 1 felt (EthAddress) |
| SNIP-163 Sessions | `supports_interface(0x037ab…55d)` | `1` (true) |
| Braavos MFA | `get_signers()` | >4 felts (existing) |

Detection order: Shhh Ed25519 → Shhh EVM → SNIP-163 → Braavos → none.

## Gas overhead values

| Account | L2 Gas Overhead | Source |
|---|---|---|
| Shhh Ed25519 | ~80M (`0x04c4b400`) | Garaga MSM+EdDSA ~33M + bytes_to_hex_ascii ~5M + OE encoding ~3M + Serde deserialization ~5M + byte comparison loop ~2M + storage ~2M |
| Shhh EVM | ~20M (`0x01312D00`) | keccak256 syscall ~5M + ecrecover ~8M + OE encoding ~3M + ByteArray loops ~2M + storage ~2M |
| SNIP-163 Sessions | ~20M (`0x01312D00`) | Dual SNIP-12 hash + 2x ECDSA + session reads + whitelist iteration + spending policy |
| Braavos MFA | ~46.8M (`0x02c7ab80`) | Existing |

Values measured on mainnet. Only affects gas limits, not actual gas consumed or sponsored amount.

## References

- Shhh Ed25519 wallet: https://github.com/haycarlitos/shhh-wallet-cairo
- Shhh EVM wallet: same repo, `src/wallet_evm.cairo`
- SNIP-163 (session keys standard): https://github.com/starknet-io/SNIPs/pull/163
- Chipi sessions contract: https://github.com/chipi-pay/sessions-smart-contract
- Garaga v1.0.1 (Ed25519 verification): https://github.com/keep-starknet-strange/garaga
- Discussion with @florianbellotti about the approach