### PR TITLE
:bug: Apply max fee overhead to privacy pool fee

### DIFF
--- a/crates/paymaster-execution/src/execution/build.rs
+++ b/crates/paymaster-execution/src/execution/build.rs
@@ -368,10 +368,9 @@ impl PrivateTransaction {
         let estimated_fee_in_strk = Felt::from(user_calls_fee + privacy_overhead);
         let estimated_fee_in_gas_token = convert_strk_to_token(&token, estimated_fee_in_strk, true)?;
 
-        // Add pool fee (not multiplied — it's a fixed known cost)
         let total_fee_in_strk = estimated_fee_in_strk + Felt::from(self.pool_fee_amount);
 
-        let suggested_max_fee_in_strk = client.compute_max_fee_in_strk(estimated_fee_in_strk) + Felt::from(self.pool_fee_amount);
+        let suggested_max_fee_in_strk = client.compute_max_fee_in_strk(total_fee_in_strk);
         let suggested_max_fee_in_gas_token = convert_strk_to_token(&token, suggested_max_fee_in_strk, true)?;
 
         let typed_data = if let Some(user_calls) = self.user_calls {
@@ -397,7 +396,8 @@ impl PrivateTransaction {
         // In sponsored mode the relayer covers gas but the user still pays the pool fee
         let fee_action_amount = if self.parameters.fee_mode().is_sponsored() {
             if self.pool_fee_amount > 0 {
-                convert_strk_to_token(&token, Felt::from(self.pool_fee_amount), true)?
+                let pool_fee_with_overhead = client.compute_max_fee_in_strk(Felt::from(self.pool_fee_amount));
+                convert_strk_to_token(&token, pool_fee_with_overhead, true)?
             } else {
                 Felt::ZERO
             }


### PR DESCRIPTION
## Summary
- Fixes `POOL_FEE_TOO_LOW` (167) on `paymaster_executeTransaction` for `apply_action` in `sponsored_private` mode when `pool_fee_token` is not STRK (reproduced with USDC on mainnet).
- Root cause: the `max_fee_multiplier` was applied only to the gas portion; the privacy pool fee was added raw. With a non-STRK fee token, STRK↔token price drift between build and execute left the user-approved pool-fee transfer short of the executor's re-computed amount.
- Fix: fold `pool_fee_amount` into the total before applying `compute_max_fee_in_strk`, and apply the same overhead to the sponsored-mode `fee_action_amount`.

## Test plan
- [x] `cargo build -p paymaster-execution`
- [x] `cargo clippy -p paymaster-execution` (no new warnings)
- [x] `cargo test -p paymaster-execution` (all tests pass)
- [ ] Mainnet repro: re-submit the failing `apply_action` tx in `sponsored_private` with `pool_fee_token = USDC` and confirm no `POOL_FEE_TOO_LOW`
- [ ] Regression check with `pool_fee_token = STRK`
- [ ] Regression check on non-sponsored private flow