### PR TITLE
Approve privacy pool to pull STRK fee in forwarder

### DIFF
--- a/contracts/src/forwarder.cairo
+++ b/contracts/src/forwarder.cairo
@@ -2,6 +2,11 @@ use starknet::ContractAddress;
 use starknet::account::Call;
 
 #[starknet::interface]
+pub trait IPrivacyPool<TContractState> {
+    fn get_fee_amount(self: @TContractState) -> u128;
+}
+
+#[starknet::interface]
 pub trait IForwarder<TContractState> {
     fn get_gas_fees_recipient(self: @TContractState) -> ContractAddress;
     fn set_gas_fees_recipient(ref self: TContractState, gas_fees_recipient: ContractAddress) -> bool;
@@ -46,7 +51,10 @@ pub mod Forwarder {
     use starknet::syscalls::call_contract_syscall;
     use starknet::account::Call;
     use starknet::{ContractAddress, SyscallResultTrait, get_caller_address, get_contract_address};
-    use super::IForwarder;
+    use super::{IForwarder, IPrivacyPoolDispatcher, IPrivacyPoolDispatcherTrait};
+
+    // 10_000 STRK in FRI (18 decimals). Safety cap against a misconfigured or malicious pool.
+    const MAX_POOL_FEE: u256 = 10_000_000_000_000_000_000_000_u256;
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
     component!(path: UpgradableComponent, storage: upgradable, event: UpgradableEvent);
@@ -94,6 +102,20 @@ pub mod Forwarder {
     fn constructor(ref self: ContractState, owner: ContractAddress, gas_fees_recipient: ContractAddress) {
         self.ownable.initialize(owner);
         self.gas_fees_recipient.write(gas_fees_recipient);
+    }
+
+    // The last call of every private batch targets the privacy pool; approve the pool to pull
+    // its STRK fee during `apply_actions` (it uses `transferFrom` from this contract).
+    fn approve_pool_fee(gas_token: IERC20Dispatcher, calls: @Array<Call>) {
+        assert(calls.len() > 0, 'Empty calls');
+        let last_call = calls.at(calls.len() - 1);
+        let pool_address = *last_call.to;
+        let pool = IPrivacyPoolDispatcher { contract_address: pool_address };
+        let fee_amount: u256 = pool.get_fee_amount().into();
+        assert(fee_amount <= MAX_POOL_FEE, 'Pool fee exceeds limit');
+        if fee_amount > 0 {
+            gas_token.approve(pool_address, fee_amount);
+        }
     }
 
     #[abi(embed_v0)]
@@ -167,6 +189,8 @@ pub mod Forwarder {
             let gas_token = IERC20Dispatcher { contract_address: gas_token_address };
             let balance_before = gas_token.balanceOf(contract_address);
 
+            approve_pool_fee(gas_token, @calls);
+
             // Execute each call
             for call in calls {
                 call_contract_syscall(call.to, call.selector, call.calldata).unwrap_syscall();
@@ -198,12 +222,14 @@ pub mod Forwarder {
             let contract_address = get_contract_address();
 
             // Snapshot balance before execution so we can verify the pool fee was actually paid
+            let gas_token = IERC20Dispatcher { contract_address: gas_token_address };
             let balance_before = if gas_amount > 0 {
-                let gas_token = IERC20Dispatcher { contract_address: gas_token_address };
                 gas_token.balanceOf(contract_address)
             } else {
                 0_u256
             };
+
+            approve_pool_fee(gas_token, @calls);
 
             // Execute each call
             for call in calls {
@@ -212,7 +238,6 @@ pub mod Forwarder {
 
             // Collect pool fee if any
             if gas_amount > 0 {
-                let gas_token = IERC20Dispatcher { contract_address: gas_token_address };
                 let balance_after = gas_token.balanceOf(contract_address);
                 let received = balance_after - balance_before;
                 assert(received >= gas_amount, 'Insufficient pool fee payment');

--- a/contracts/tests/forwarder_test.cairo
+++ b/contracts/tests/forwarder_test.cairo
@@ -3,7 +3,7 @@ use avnu_lib::components::ownable::IOwnableDispatcherTrait;
 use avnu_lib::components::whitelist::IWhitelistDispatcherTrait;
 use starknet::contract_address_const;
 use starknet::testing::set_contract_address;
-use super::helper::{deploy_forwarder, deploy_mock_account, deploy_mock_token};
+use super::helper::{deploy_forwarder, deploy_mock_account, deploy_mock_pool, deploy_mock_token};
 
 mod GetGasFessRecipient {
     use super::{IForwarderDispatcherTrait, contract_address_const, deploy_forwarder};
@@ -158,11 +158,13 @@ mod ExecutePrivate {
     use starknet::account::Call;
     use super::{
         IForwarderDispatcherTrait, IOwnableDispatcherTrait, IWhitelistDispatcherTrait, contract_address_const, deploy_forwarder,
-        deploy_mock_token, set_contract_address,
+        deploy_mock_pool, deploy_mock_token, set_contract_address,
     };
 
     // selector!("mint")
     const MINT_SELECTOR: felt252 = 0x02f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354;
+    // selector!("apply_actions")
+    const APPLY_ACTIONS_SELECTOR: felt252 = selector!("apply_actions");
 
     #[test]
     #[available_gas(2000000000)]
@@ -178,13 +180,16 @@ mod ExecutePrivate {
         let gas_token_address = gas_token.contract_address;
         let gas_amount: u256 = 5_u256;
 
-        // Calls: mint gas_amount tokens to the forwarder during execution
+        // Deploy a mock privacy pool — the last call of every private batch targets the pool
+        let pool = deploy_mock_pool(0_u128, contract_address_const::<0x123>(), contract_address_const::<0x0>());
+        // Calls: mint gas_amount tokens to the forwarder during execution, then call the pool
         let calls: Array<Call> = array![
             Call {
                 to: gas_token_address,
                 selector: MINT_SELECTOR,
                 calldata: array![forwarder.contract_address.into(), 5, 0].span(),
             },
+            Call { to: pool.contract_address, selector: APPLY_ACTIONS_SELECTOR, calldata: array![].span() },
         ];
         set_contract_address(caller);
 
@@ -212,7 +217,8 @@ mod ExecutePrivate {
         let gas_token_address = gas_token.contract_address;
         let gas_amount: u256 = 3_u256;
 
-        // Calls: two mints, total 5 tokens but only 3 required as gas
+        let pool = deploy_mock_pool(0_u128, contract_address_const::<0x123>(), contract_address_const::<0x0>());
+        // Calls: two mints (total 5 tokens, only 3 required as gas) followed by the pool call
         let calls: Array<Call> = array![
             Call {
                 to: gas_token_address,
@@ -224,6 +230,7 @@ mod ExecutePrivate {
                 selector: MINT_SELECTOR,
                 calldata: array![forwarder.contract_address.into(), 3, 0].span(),
             },
+            Call { to: pool.contract_address, selector: APPLY_ACTIONS_SELECTOR, calldata: array![].span() },
         ];
         set_contract_address(caller);
 
@@ -266,13 +273,15 @@ mod ExecutePrivate {
         let gas_token = deploy_mock_token(contract_address_const::<0x0>(), 0);
         let gas_token_address = gas_token.contract_address;
 
-        // Mint only 2 tokens but require 5
+        let pool = deploy_mock_pool(0_u128, contract_address_const::<0x123>(), contract_address_const::<0x0>());
+        // Mint only 2 tokens but require 5, then call the pool
         let calls: Array<Call> = array![
             Call {
                 to: gas_token_address,
                 selector: MINT_SELECTOR,
                 calldata: array![forwarder.contract_address.into(), 2, 0].span(),
             },
+            Call { to: pool.contract_address, selector: APPLY_ACTIONS_SELECTOR, calldata: array![].span() },
         ];
         set_contract_address(caller);
 
@@ -286,11 +295,12 @@ mod ExecutePrivateSponsored {
     use starknet::account::Call;
     use super::{
         IForwarderDispatcherTrait, IOwnableDispatcherTrait, IWhitelistDispatcherTrait, contract_address_const, deploy_forwarder,
-        deploy_mock_account, deploy_mock_token, set_contract_address,
+        deploy_mock_account, deploy_mock_pool, deploy_mock_token, set_contract_address,
     };
 
     // selector!("mint")
     const MINT_SELECTOR: felt252 = 0x02f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354;
+    const APPLY_ACTIONS_SELECTOR: felt252 = selector!("apply_actions");
 
     #[test]
     #[available_gas(2000000000)]
@@ -303,8 +313,10 @@ mod ExecutePrivateSponsored {
         whitelist.set_whitelisted_address(caller, true);
         let account = deploy_mock_account();
         let entrypoint: felt252 = 0x361458367e696363fbcc70777d07ebbd2394e89fd0adcaf147faccd1d294d60;
+        let pool = deploy_mock_pool(0_u128, contract_address_const::<0x123>(), contract_address_const::<0x0>());
         let calls: Array<Call> = array![
             Call { to: account.contract_address, selector: entrypoint, calldata: array![].span() },
+            Call { to: pool.contract_address, selector: APPLY_ACTIONS_SELECTOR, calldata: array![].span() },
         ];
         let gas_token_address = contract_address_const::<0x0>();
         set_contract_address(caller);
@@ -331,13 +343,15 @@ mod ExecutePrivateSponsored {
         let gas_token_address = gas_token.contract_address;
         let pool_fee: u256 = 3_u256;
 
-        // Calls: mint pool_fee tokens to the forwarder (simulates TransferTo from apply_actions)
+        let pool = deploy_mock_pool(0_u128, contract_address_const::<0x123>(), contract_address_const::<0x0>());
+        // Calls: mint pool_fee tokens to the forwarder (simulates TransferTo from apply_actions), then the pool call
         let calls: Array<Call> = array![
             Call {
                 to: gas_token_address,
                 selector: MINT_SELECTOR,
                 calldata: array![forwarder.contract_address.into(), 3, 0].span(),
             },
+            Call { to: pool.contract_address, selector: APPLY_ACTIONS_SELECTOR, calldata: array![].span() },
         ];
         set_contract_address(caller);
 
@@ -367,13 +381,15 @@ mod ExecutePrivateSponsored {
         let gas_token = deploy_mock_token(forwarder.contract_address, 10);
         let gas_token_address = gas_token.contract_address;
 
-        // Mint only 2 tokens but require 5 — pre-existing balance must not help
+        let pool = deploy_mock_pool(0_u128, contract_address_const::<0x123>(), contract_address_const::<0x0>());
+        // Mint only 2 tokens but require 5 — pre-existing balance must not help; then the pool call
         let calls: Array<Call> = array![
             Call {
                 to: gas_token_address,
                 selector: MINT_SELECTOR,
                 calldata: array![forwarder.contract_address.into(), 2, 0].span(),
             },
+            Call { to: pool.contract_address, selector: APPLY_ACTIONS_SELECTOR, calldata: array![].span() },
         ];
         set_contract_address(caller);
 
@@ -396,5 +412,57 @@ mod ExecutePrivateSponsored {
 
         // When & Then
         forwarder.execute_private_sponsored(calls, gas_token_address, 0_u256, sponsor_metadata);
+    }
+
+    #[test]
+    #[available_gas(2000000000)]
+    fn should_approve_pool_and_let_pool_pull_fee() {
+        // Given — pool with fee=3, forwarder pre-holds 10 STRK so the pool's transferFrom succeeds
+        let (forwarder, ownable, whitelist) = deploy_forwarder();
+        let caller = contract_address_const::<0x999>();
+        let sponsor_metadata: Array<felt252> = array!['SPONSOR_ID'];
+        set_contract_address(ownable.get_owner());
+        whitelist.set_whitelisted_address(caller, true);
+        let strk = deploy_mock_token(forwarder.contract_address, 10);
+        let fee_collector = contract_address_const::<0xFEE>();
+        let pool_fee: u128 = 3_u128;
+        let pool = deploy_mock_pool(pool_fee, fee_collector, strk.contract_address);
+        let calls: Array<Call> = array![
+            Call { to: pool.contract_address, selector: APPLY_ACTIONS_SELECTOR, calldata: array![].span() },
+        ];
+        set_contract_address(caller);
+
+        // When — gas_amount=0 so the sponsor path skips its own balance accounting; only the
+        // pool's transferFrom moves tokens, proving the forwarder granted an allowance to the pool.
+        let result = forwarder.execute_private_sponsored(calls, strk.contract_address, 0_u256, sponsor_metadata);
+
+        // Then
+        assert(result == true, 'invalid result');
+        assert(strk.balanceOf(fee_collector) == 3_u256, 'fee collector not paid');
+        assert(strk.balanceOf(forwarder.contract_address) == 7_u256, 'forwarder not debited');
+    }
+
+    #[test]
+    #[available_gas(2000000000)]
+    #[should_panic(expected: ('Pool fee exceeds limit', 'ENTRYPOINT_FAILED'))]
+    fn should_fail_when_pool_fee_exceeds_limit() {
+        // Given — pool with a fee just over MAX_POOL_FEE (10_000 STRK in FRI)
+        let (forwarder, ownable, whitelist) = deploy_forwarder();
+        let caller = contract_address_const::<0x999>();
+        let sponsor_metadata: Array<felt252> = array!['SPONSOR_ID'];
+        set_contract_address(ownable.get_owner());
+        whitelist.set_whitelisted_address(caller, true);
+        let strk = deploy_mock_token(forwarder.contract_address, 0);
+        let fee_collector = contract_address_const::<0xFEE>();
+        // 10_000 STRK + 1 FRI
+        let pool_fee: u128 = 10_000_000_000_000_000_000_001_u128;
+        let pool = deploy_mock_pool(pool_fee, fee_collector, strk.contract_address);
+        let calls: Array<Call> = array![
+            Call { to: pool.contract_address, selector: APPLY_ACTIONS_SELECTOR, calldata: array![].span() },
+        ];
+        set_contract_address(caller);
+
+        // When & Then
+        forwarder.execute_private_sponsored(calls, strk.contract_address, 0_u256, sponsor_metadata);
     }
 }

--- a/contracts/tests/helper.cairo
+++ b/contracts/tests/helper.cairo
@@ -7,6 +7,7 @@ use starknet::syscalls::deploy_syscall;
 use starknet::testing::pop_log_raw;
 use super::mocks::account_mock::{IAccountDispatcher, MockAccount};
 use super::mocks::erc20_mock::ERC20Mock;
+use super::mocks::privacy_pool_mock::{IMockPrivacyPoolDispatcher, MockPrivacyPool};
 
 pub fn deploy_mock_token(recipient: ContractAddress, balance: felt252) -> IERC20Dispatcher {
     let mut constructor_args: Array<felt252> = ArrayTrait::new();
@@ -23,6 +24,18 @@ pub fn deploy_mock_account() -> IAccountDispatcher {
     let (token_address, _) = deploy_syscall(MockAccount::TEST_CLASS_HASH.try_into().unwrap(), 0, constructor_args.span(), false)
         .expect('account deploy failed');
     return IAccountDispatcher { contract_address: token_address };
+}
+
+pub fn deploy_mock_pool(
+    fee_amount: u128, fee_collector: ContractAddress, strk_token: ContractAddress,
+) -> IMockPrivacyPoolDispatcher {
+    let mut constructor_args: Array<felt252> = ArrayTrait::new();
+    constructor_args.append(fee_amount.into());
+    constructor_args.append(fee_collector.into());
+    constructor_args.append(strk_token.into());
+    let (pool_address, _) = deploy_syscall(MockPrivacyPool::TEST_CLASS_HASH.try_into().unwrap(), 0, constructor_args.span(), false)
+        .expect('pool deploy failed');
+    return IMockPrivacyPoolDispatcher { contract_address: pool_address };
 }
 
 pub fn deploy_forwarder() -> (IForwarderDispatcher, IOwnableDispatcher, IWhitelistDispatcher) {

--- a/contracts/tests/mocks.cairo
+++ b/contracts/tests/mocks.cairo
@@ -1,2 +1,3 @@
 pub mod account_mock;
 pub mod erc20_mock;
+pub mod privacy_pool_mock;

--- a/contracts/tests/mocks/erc20_mock.cairo
+++ b/contracts/tests/mocks/erc20_mock.cairo
@@ -6,6 +6,7 @@ pub trait IERC20<TStorage> {
     fn transfer(ref self: TStorage, to: ContractAddress, amount: u256);
     fn transferFrom(ref self: TStorage, from: ContractAddress, to: ContractAddress, amount: u256);
     fn balanceOf(self: @TStorage, account: ContractAddress) -> u256;
+    fn allowance(self: @TStorage, owner: ContractAddress, spender: ContractAddress) -> u256;
     fn mint(ref self: TStorage, account: ContractAddress, amount: u256);
     fn burn(ref self: TStorage, account: ContractAddress, amount: u256);
 }
@@ -63,6 +64,10 @@ pub mod ERC20Mock {
         fn approve(ref self: ContractState, spender: ContractAddress, amount: u256) {
             let caller = get_caller_address();
             self._approve(caller, spender, amount);
+        }
+
+        fn allowance(self: @ContractState, owner: ContractAddress, spender: ContractAddress) -> u256 {
+            self.ERC20_allowances.read((owner, spender))
         }
 
         fn mint(ref self: ContractState, account: ContractAddress, amount: u256) {

--- a/contracts/tests/mocks/privacy_pool_mock.cairo
+++ b/contracts/tests/mocks/privacy_pool_mock.cairo
@@ -1,0 +1,55 @@
+use starknet::ContractAddress;
+
+#[starknet::interface]
+pub trait IMockPrivacyPool<TStorage> {
+    fn get_fee_amount(self: @TStorage) -> u128;
+    fn get_fee_collector(self: @TStorage) -> ContractAddress;
+    fn apply_actions(ref self: TStorage);
+}
+
+
+#[starknet::contract]
+pub mod MockPrivacyPool {
+    use avnu_lib::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+    use starknet::{ContractAddress, get_caller_address};
+    use super::IMockPrivacyPool;
+
+    #[storage]
+    struct Storage {
+        fee_amount: u128,
+        fee_collector: ContractAddress,
+        strk_token: ContractAddress,
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState, fee_amount: u128, fee_collector: ContractAddress, strk_token: ContractAddress,
+    ) {
+        self.fee_amount.write(fee_amount);
+        self.fee_collector.write(fee_collector);
+        self.strk_token.write(strk_token);
+    }
+
+    #[abi(embed_v0)]
+    impl PoolImpl of IMockPrivacyPool<ContractState> {
+        fn get_fee_amount(self: @ContractState) -> u128 {
+            self.fee_amount.read()
+        }
+
+        fn get_fee_collector(self: @ContractState) -> ContractAddress {
+            self.fee_collector.read()
+        }
+
+        // Mirrors privacy.cairo:collect_fee — pulls `fee_amount` STRK from the caller
+        // (the forwarder in practice) to `fee_collector` using transferFrom.
+        fn apply_actions(ref self: ContractState) {
+            let fee: u128 = self.fee_amount.read();
+            if fee > 0 {
+                let token = IERC20Dispatcher { contract_address: self.strk_token.read() };
+                let collector = self.fee_collector.read();
+                token.transferFrom(get_caller_address(), collector, fee.into());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- The last call of every private batch (`execute_private` / `execute_private_sponsored`) targets a privacy pool whose `apply_actions` uses `transferFrom` to collect its STRK fee from `msg.sender` (the forwarder). Without a prior allowance, that transfer reverts — so pools with a non-zero fee can't currently be called through the forwarder.
- Added an `IPrivacyPool` dispatcher (just `get_fee_amount`) and a 10_000 STRK `MAX_POOL_FEE` safety cap.
- New `approve_pool_fee` helper reads the pool address from the last call's `to`, queries the fee, asserts the cap, and approves the **pool** (not the `fee_collector`) to pull the STRK.
- Wired into both `execute_private` and `execute_private_sponsored` before the call loop.
- Added `MockPrivacyPool` whose `apply_actions` mirrors the real pool's `collect_fee` via `transferFrom`, plus tests for the end-to-end approve flow and the fee-limit guard.

## Test plan

- [x] `scarb build` in `contracts/`
- [x] `scarb test` — 17/17 passing, including:
  - `ExecutePrivateSponsored::should_approve_pool_and_let_pool_pull_fee` — verifies the forwarder's allowance lets the pool pull 3 STRK end-to-end to the fee collector
  - `ExecutePrivateSponsored::should_fail_when_pool_fee_exceeds_limit` — reverts with `'Pool fee exceeds limit'` when pool fee is above `MAX_POOL_FEE`
- [ ] Manual check against a real privacy pool on testnet