### PR TITLE
:bug: Apply only provider overhead to privacy pool fee

### DIFF
--- a/crates/paymaster-execution/src/execution/build.rs
+++ b/crates/paymaster-execution/src/execution/build.rs
@@ -370,7 +370,11 @@ impl PrivateTransaction {
 
         let total_fee_in_strk = estimated_fee_in_strk + Felt::from(self.pool_fee_amount);
 
-        let suggested_max_fee_in_strk = client.compute_max_fee_in_strk(total_fee_in_strk);
+        // Apply the max_fee multiplier only to the estimated gas fee (which can drift at execute time).
+        // The pool fee is a fixed amount in STRK read from the pool, so we only add the smaller
+        // provider overhead to cover STRK / gas-token price drift between build and execute.
+        let suggested_max_fee_in_strk =
+            client.compute_max_fee_in_strk(estimated_fee_in_strk) + client.compute_paid_fee_in_strk(Felt::from(self.pool_fee_amount));
         let suggested_max_fee_in_gas_token = convert_strk_to_token(&token, suggested_max_fee_in_strk, true)?;
 
         let typed_data = if let Some(user_calls) = self.user_calls {
@@ -396,7 +400,7 @@ impl PrivateTransaction {
         // In sponsored mode the relayer covers gas but the user still pays the pool fee
         let fee_action_amount = if self.parameters.fee_mode().is_sponsored() {
             if self.pool_fee_amount > 0 {
-                let pool_fee_with_overhead = client.compute_max_fee_in_strk(Felt::from(self.pool_fee_amount));
+                let pool_fee_with_overhead = client.compute_paid_fee_in_strk(Felt::from(self.pool_fee_amount));
                 convert_strk_to_token(&token, pool_fee_with_overhead, true)?
             } else {
                 Felt::ZERO


### PR DESCRIPTION
## Summary

- Follow-up to #72: that PR applied `max_fee_multiplier` (~3x) to the pool fee, which caused users to approve triple the amount they actually owed.
  - Observed: pool fee went from 192k → 513k wei USDC (~2.66x). Transactions then fail with "Insufficient ERC20 balance" because the user is asked to approve more than they hold.
- Root cause: the pool fee is a fixed amount in STRK read from the pool — it does not need the large safety multiplier that guards against gas-fee volatility. A small overhead to cover STRK / gas-token price drift between build and execute is sufficient.
- Fix: use `compute_paid_fee_in_strk` (~`1 + provider_fee_overhead` ≈ 1.1x) on the pool portion; keep `compute_max_fee_in_strk` (~3x) on the estimated gas portion.

## Test plan

- [x] `cargo build -p paymaster-execution`
- [x] `cargo test -p paymaster-execution` — 33/33 passing
- [x] `cargo clippy -p paymaster-execution` — no new warnings
- [ ] Mainnet repro with `pool_fee_token = USDC`: confirm approve amount is now pool_fee × ~1.1 instead of × ~2.66, and no "Insufficient ERC20 balance"
- [ ] Regression check with `pool_fee_token = STRK`
- [ ] Regression on non-sponsored private flow