### PR TITLE
:sparkles: Pre-fund forwarder with STRK for privacy pool fee

### DIFF
--- a/crates/paymaster-execution/src/execution/execute.rs
+++ b/crates/paymaster-execution/src/execution/execute.rs
@@ -1,4 +1,5 @@
 use paymaster_prices::math::convert_strk_to_token;
+use paymaster_starknet::constants::Token;
 use paymaster_starknet::transaction::{
     parse_server_actions, CalldataBuilder, Calls, EstimatedCalls, ExecuteFromOutsideMessage, PrivateProofData, SequentialCalldataDecoder, ServerAction, TokenTransfer,
 };
@@ -397,6 +398,17 @@ impl ExecutableTransaction {
         Calls::new(calls)
     }
 
+    /// The privacy pool collects its fee in STRK via `transferFrom(forwarder, ...)`. The forwarder is
+    /// never paid in STRK — the user may be paying in a different gas token (USDC, etc.) — so the
+    /// relayer seeds the forwarder's STRK balance before the forwarder call. The relayer is later
+    /// reimbursed through the standard gas-tank → relayers STRK rebalancing cycle.
+    fn build_pool_fee_pretransfer_call(&self) -> Option<Call> {
+        if self.privacy_pool_fee_amount == 0 {
+            return None;
+        }
+        Some(TokenTransfer::new(Token::STRK_ADDRESS, self.forwarder, Felt::from(self.privacy_pool_fee_amount)).to_call())
+    }
+
     /// Validate and build the inner calls for a private transaction (optional execute_from_outside + apply_actions)
     fn build_private_inner_calls(&self, invoke: Option<&ExecutableInvokeParameters>, apply_action: &ExecutableApplyActionParameters) -> Result<Vec<Call>, Error> {
         let apply_call = &apply_action.apply_actions_call;
@@ -445,7 +457,12 @@ impl ExecutableTransaction {
                 .build(),
         };
 
-        Ok(Calls::new(vec![forwarder_call]))
+        let mut calls = Vec::with_capacity(2);
+        if let Some(pretransfer) = self.build_pool_fee_pretransfer_call() {
+            calls.push(pretransfer);
+        }
+        calls.push(forwarder_call);
+        Ok(Calls::new(calls))
     }
 
     /// Build calls for a gasless private transaction using `execute_private`
@@ -468,7 +485,12 @@ impl ExecutableTransaction {
                 .build(),
         };
 
-        Ok(Calls::new(vec![forwarder_call]))
+        let mut calls = Vec::with_capacity(2);
+        if let Some(pretransfer) = self.build_pool_fee_pretransfer_call() {
+            calls.push(pretransfer);
+        }
+        calls.push(forwarder_call);
+        Ok(Calls::new(calls))
     }
 
     fn build_deploy_call(&self) -> Option<Call> {


### PR DESCRIPTION
## Summary

When a private transaction uses a pool fee, the privacy pool collects it via `transferFrom(forwarder, fee_collector, fee)` in **STRK**. If the user is paying in a different gas token (e.g. USDC), the forwarder ends up holding USDC but zero STRK, and `apply_actions` reverts — even with a correct approve in place.

The relayer already holds STRK (refilled via the gas-tank → relayers rebalancing cycle), so we prepend a `strk.transfer(forwarder, pool_fee_amount)` call before the forwarder call on both private flows:

- `build_private_calls` (gasless private via `execute_private`)
- `build_private_sponsored_calls` (sponsored private via `execute_private_sponsored`)

The relayer is reimbursed when the forwarder forwards the user's gas-token payment to the gas tank — the existing rebalancing later converts that back to STRK and tops the relayer up. The change is a no-op for transactions with `privacy_pool_fee_amount == 0`.

## Related

- This depends on the forwarder approving the pool to pull its STRK fee (#73). Without the approve, the pool's `transferFrom` still reverts even if the balance is there.
- Orthogonal to the fee-amount fix in #74.

## Known edge case

When `gas_token == STRK`, the forwarder's `received >= gas_amount` assertion can under-count because the pool pulls STRK from the same balance the forwarder tracks. The non-STRK path (the reported USDC bug) works as intended; STRK-gas-token with pool fee would need either a forwarder-contract change or splitting the user deposit. Flagged for a follow-up.

## Test plan

- [x] `cargo build -p paymaster-execution`
- [x] `cargo test -p paymaster-execution` — 33/33 passing
- [ ] Mainnet repro with `pool_fee_token = USDC` and `privacy_pool_fee_amount > 0`: confirm `apply_actions` no longer fails on pool's `transferFrom`
- [ ] Regression check on private flow with `privacy_pool_fee_amount = 0` (no extra call emitted)
- [ ] Verify relayer STRK balance moves as expected and rebalancing tops it up