### PR TITLE
:bug: Fix privacy pool fee flow (approve + overhead + STRK pre-fund)

### DIFF
--- a/contracts/src/forwarder.cairo
+++ b/contracts/src/forwarder.cairo
@@ -2,6 +2,11 @@ use starknet::ContractAddress;
 use starknet::account::Call;
 
 #[starknet::interface]
+pub trait IPrivacyPool<TContractState> {
+    fn get_fee_amount(self: @TContractState) -> u128;
+}
+
+#[starknet::interface]
 pub trait IForwarder<TContractState> {
     fn get_gas_fees_recipient(self: @TContractState) -> ContractAddress;
     fn set_gas_fees_recipient(ref self: TContractState, gas_fees_recipient: ContractAddress) -> bool;
@@ -46,7 +51,12 @@ pub mod Forwarder {
     use starknet::syscalls::call_contract_syscall;
     use starknet::account::Call;
     use starknet::{ContractAddress, SyscallResultTrait, get_caller_address, get_contract_address};
-    use super::IForwarder;
+    use super::{IForwarder, IPrivacyPoolDispatcher, IPrivacyPoolDispatcherTrait};
+
+    const STRK_TOKEN_ADDRESS: felt252 = 0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d;
+
+    // 10_000 STRK in FRI (18 decimals). Safety cap against a misconfigured or malicious pool.
+    const MAX_POOL_FEE: u256 = 10_000_000_000_000_000_000_000_u256;
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
     component!(path: UpgradableComponent, storage: upgradable, event: UpgradableEvent);
@@ -94,6 +104,22 @@ pub mod Forwarder {
     fn constructor(ref self: ContractState, owner: ContractAddress, gas_fees_recipient: ContractAddress) {
         self.ownable.initialize(owner);
         self.gas_fees_recipient.write(gas_fees_recipient);
+    }
+
+    // The last call of every private batch targets the privacy pool; approve the pool to pull
+    // its STRK fee during `apply_actions`. The pool always collects fees in STRK, independent
+    // of the gas token the user is paying in.
+    fn approve_pool_fee(calls: @Array<Call>) {
+        assert(calls.len() > 0, 'Empty calls');
+        let last_call = calls.at(calls.len() - 1);
+        let pool_address = *last_call.to;
+        let pool = IPrivacyPoolDispatcher { contract_address: pool_address };
+        let fee_amount: u256 = pool.get_fee_amount().into();
+        assert(fee_amount <= MAX_POOL_FEE, 'Pool fee exceeds limit');
+        if fee_amount > 0 {
+            let strk = IERC20Dispatcher { contract_address: STRK_TOKEN_ADDRESS.try_into().unwrap() };
+            strk.approve(pool_address, fee_amount);
+        }
     }
 
     #[abi(embed_v0)]
@@ -167,6 +193,8 @@ pub mod Forwarder {
             let gas_token = IERC20Dispatcher { contract_address: gas_token_address };
             let balance_before = gas_token.balanceOf(contract_address);
 
+            approve_pool_fee(@calls);
+
             // Execute each call
             for call in calls {
                 call_contract_syscall(call.to, call.selector, call.calldata).unwrap_syscall();
@@ -198,12 +226,14 @@ pub mod Forwarder {
             let contract_address = get_contract_address();
 
             // Snapshot balance before execution so we can verify the pool fee was actually paid
+            let gas_token = IERC20Dispatcher { contract_address: gas_token_address };
             let balance_before = if gas_amount > 0 {
-                let gas_token = IERC20Dispatcher { contract_address: gas_token_address };
                 gas_token.balanceOf(contract_address)
             } else {
                 0_u256
             };
+
+            approve_pool_fee(@calls);
 
             // Execute each call
             for call in calls {
@@ -212,7 +242,6 @@ pub mod Forwarder {
 
             // Collect pool fee if any
             if gas_amount > 0 {
-                let gas_token = IERC20Dispatcher { contract_address: gas_token_address };
                 let balance_after = gas_token.balanceOf(contract_address);
                 let received = balance_after - balance_before;
                 assert(received >= gas_amount, 'Insufficient pool fee payment');

--- a/contracts/tests/forwarder_test.cairo
+++ b/contracts/tests/forwarder_test.cairo
@@ -3,7 +3,7 @@ use avnu_lib::components::ownable::IOwnableDispatcherTrait;
 use avnu_lib::components::whitelist::IWhitelistDispatcherTrait;
 use starknet::contract_address_const;
 use starknet::testing::set_contract_address;
-use super::helper::{deploy_forwarder, deploy_mock_account, deploy_mock_token};
+use super::helper::{deploy_forwarder, deploy_mock_account, deploy_mock_pool, deploy_mock_token};
 
 mod GetGasFessRecipient {
     use super::{IForwarderDispatcherTrait, contract_address_const, deploy_forwarder};
@@ -158,11 +158,12 @@ mod ExecutePrivate {
     use starknet::account::Call;
     use super::{
         IForwarderDispatcherTrait, IOwnableDispatcherTrait, IWhitelistDispatcherTrait, contract_address_const, deploy_forwarder,
-        deploy_mock_token, set_contract_address,
+        deploy_mock_pool, deploy_mock_token, set_contract_address,
     };
 
     // selector!("mint")
     const MINT_SELECTOR: felt252 = 0x02f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354;
+    const APPLY_ACTIONS_SELECTOR: felt252 = selector!("apply_actions");
 
     #[test]
     #[available_gas(2000000000)]
@@ -178,13 +179,17 @@ mod ExecutePrivate {
         let gas_token_address = gas_token.contract_address;
         let gas_amount: u256 = 5_u256;
 
-        // Calls: mint gas_amount tokens to the forwarder during execution
+        // The last call of a private batch is always the pool call; use a fee=0 mock here
+        // so the approve path short-circuits without touching STRK.
+        let pool = deploy_mock_pool(0_u128);
+        // Calls: mint gas_amount tokens to the forwarder, then invoke the pool.
         let calls: Array<Call> = array![
             Call {
                 to: gas_token_address,
                 selector: MINT_SELECTOR,
                 calldata: array![forwarder.contract_address.into(), 5, 0].span(),
             },
+            Call { to: pool.contract_address, selector: APPLY_ACTIONS_SELECTOR, calldata: array![].span() },
         ];
         set_contract_address(caller);
 
@@ -212,7 +217,8 @@ mod ExecutePrivate {
         let gas_token_address = gas_token.contract_address;
         let gas_amount: u256 = 3_u256;
 
-        // Calls: two mints, total 5 tokens but only 3 required as gas
+        let pool = deploy_mock_pool(0_u128);
+        // Calls: two mints (total 5 tokens, only 3 required as gas), followed by the pool call.
         let calls: Array<Call> = array![
             Call {
                 to: gas_token_address,
@@ -224,6 +230,7 @@ mod ExecutePrivate {
                 selector: MINT_SELECTOR,
                 calldata: array![forwarder.contract_address.into(), 3, 0].span(),
             },
+            Call { to: pool.contract_address, selector: APPLY_ACTIONS_SELECTOR, calldata: array![].span() },
         ];
         set_contract_address(caller);
 
@@ -266,13 +273,15 @@ mod ExecutePrivate {
         let gas_token = deploy_mock_token(contract_address_const::<0x0>(), 0);
         let gas_token_address = gas_token.contract_address;
 
-        // Mint only 2 tokens but require 5
+        let pool = deploy_mock_pool(0_u128);
+        // Mint only 2 tokens but require 5; pool call appended.
         let calls: Array<Call> = array![
             Call {
                 to: gas_token_address,
                 selector: MINT_SELECTOR,
                 calldata: array![forwarder.contract_address.into(), 2, 0].span(),
             },
+            Call { to: pool.contract_address, selector: APPLY_ACTIONS_SELECTOR, calldata: array![].span() },
         ];
         set_contract_address(caller);
 
@@ -286,11 +295,12 @@ mod ExecutePrivateSponsored {
     use starknet::account::Call;
     use super::{
         IForwarderDispatcherTrait, IOwnableDispatcherTrait, IWhitelistDispatcherTrait, contract_address_const, deploy_forwarder,
-        deploy_mock_account, deploy_mock_token, set_contract_address,
+        deploy_mock_account, deploy_mock_pool, deploy_mock_token, set_contract_address,
     };
 
     // selector!("mint")
     const MINT_SELECTOR: felt252 = 0x02f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354;
+    const APPLY_ACTIONS_SELECTOR: felt252 = selector!("apply_actions");
 
     #[test]
     #[available_gas(2000000000)]
@@ -303,8 +313,10 @@ mod ExecutePrivateSponsored {
         whitelist.set_whitelisted_address(caller, true);
         let account = deploy_mock_account();
         let entrypoint: felt252 = 0x361458367e696363fbcc70777d07ebbd2394e89fd0adcaf147faccd1d294d60;
+        let pool = deploy_mock_pool(0_u128);
         let calls: Array<Call> = array![
             Call { to: account.contract_address, selector: entrypoint, calldata: array![].span() },
+            Call { to: pool.contract_address, selector: APPLY_ACTIONS_SELECTOR, calldata: array![].span() },
         ];
         let gas_token_address = contract_address_const::<0x0>();
         set_contract_address(caller);
@@ -331,13 +343,15 @@ mod ExecutePrivateSponsored {
         let gas_token_address = gas_token.contract_address;
         let pool_fee: u256 = 3_u256;
 
-        // Calls: mint pool_fee tokens to the forwarder (simulates TransferTo from apply_actions)
+        let pool = deploy_mock_pool(0_u128);
+        // Calls: mint pool_fee tokens to the forwarder (simulates TransferTo from apply_actions), then pool call.
         let calls: Array<Call> = array![
             Call {
                 to: gas_token_address,
                 selector: MINT_SELECTOR,
                 calldata: array![forwarder.contract_address.into(), 3, 0].span(),
             },
+            Call { to: pool.contract_address, selector: APPLY_ACTIONS_SELECTOR, calldata: array![].span() },
         ];
         set_contract_address(caller);
 
@@ -367,18 +381,43 @@ mod ExecutePrivateSponsored {
         let gas_token = deploy_mock_token(forwarder.contract_address, 10);
         let gas_token_address = gas_token.contract_address;
 
-        // Mint only 2 tokens but require 5 — pre-existing balance must not help
+        let pool = deploy_mock_pool(0_u128);
+        // Mint only 2 tokens but require 5 — pre-existing balance must not help; pool call appended.
         let calls: Array<Call> = array![
             Call {
                 to: gas_token_address,
                 selector: MINT_SELECTOR,
                 calldata: array![forwarder.contract_address.into(), 2, 0].span(),
             },
+            Call { to: pool.contract_address, selector: APPLY_ACTIONS_SELECTOR, calldata: array![].span() },
         ];
         set_contract_address(caller);
 
         // When & Then
         forwarder.execute_private_sponsored(calls, gas_token_address, 5_u256, sponsor_metadata);
+    }
+
+    #[test]
+    #[available_gas(2000000000)]
+    #[should_panic(expected: ('Pool fee exceeds limit', 'ENTRYPOINT_FAILED'))]
+    fn should_fail_when_pool_fee_exceeds_limit() {
+        // Given — pool with a fee just over MAX_POOL_FEE (10_000 STRK in FRI)
+        let (forwarder, ownable, whitelist) = deploy_forwarder();
+        let caller = contract_address_const::<0x999>();
+        let sponsor_metadata: Array<felt252> = array!['SPONSOR_ID'];
+        set_contract_address(ownable.get_owner());
+        whitelist.set_whitelisted_address(caller, true);
+        // 10_000 STRK + 1 FRI
+        let pool_fee: u128 = 10_000_000_000_000_000_000_001_u128;
+        let pool = deploy_mock_pool(pool_fee);
+        let gas_token_address = contract_address_const::<0x0>();
+        let calls: Array<Call> = array![
+            Call { to: pool.contract_address, selector: APPLY_ACTIONS_SELECTOR, calldata: array![].span() },
+        ];
+        set_contract_address(caller);
+
+        // When & Then
+        forwarder.execute_private_sponsored(calls, gas_token_address, 0_u256, sponsor_metadata);
     }
 
     #[test]

--- a/contracts/tests/helper.cairo
+++ b/contracts/tests/helper.cairo
@@ -7,6 +7,7 @@ use starknet::syscalls::deploy_syscall;
 use starknet::testing::pop_log_raw;
 use super::mocks::account_mock::{IAccountDispatcher, MockAccount};
 use super::mocks::erc20_mock::ERC20Mock;
+use super::mocks::privacy_pool_mock::{IMockPrivacyPoolDispatcher, MockPrivacyPool};
 
 pub fn deploy_mock_token(recipient: ContractAddress, balance: felt252) -> IERC20Dispatcher {
     let mut constructor_args: Array<felt252> = ArrayTrait::new();
@@ -23,6 +24,14 @@ pub fn deploy_mock_account() -> IAccountDispatcher {
     let (token_address, _) = deploy_syscall(MockAccount::TEST_CLASS_HASH.try_into().unwrap(), 0, constructor_args.span(), false)
         .expect('account deploy failed');
     return IAccountDispatcher { contract_address: token_address };
+}
+
+pub fn deploy_mock_pool(fee_amount: u128) -> IMockPrivacyPoolDispatcher {
+    let mut constructor_args: Array<felt252> = ArrayTrait::new();
+    constructor_args.append(fee_amount.into());
+    let (pool_address, _) = deploy_syscall(MockPrivacyPool::TEST_CLASS_HASH.try_into().unwrap(), 0, constructor_args.span(), false)
+        .expect('pool deploy failed');
+    return IMockPrivacyPoolDispatcher { contract_address: pool_address };
 }
 
 pub fn deploy_forwarder() -> (IForwarderDispatcher, IOwnableDispatcher, IWhitelistDispatcher) {

--- a/contracts/tests/mocks.cairo
+++ b/contracts/tests/mocks.cairo
@@ -1,2 +1,3 @@
 pub mod account_mock;
 pub mod erc20_mock;
+pub mod privacy_pool_mock;

--- a/contracts/tests/mocks/privacy_pool_mock.cairo
+++ b/contracts/tests/mocks/privacy_pool_mock.cairo
@@ -1,0 +1,33 @@
+use starknet::ContractAddress;
+
+#[starknet::interface]
+pub trait IMockPrivacyPool<TStorage> {
+    fn get_fee_amount(self: @TStorage) -> u128;
+    fn apply_actions(ref self: TStorage);
+}
+
+
+#[starknet::contract]
+pub mod MockPrivacyPool {
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+    use super::IMockPrivacyPool;
+
+    #[storage]
+    struct Storage {
+        fee_amount: u128,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, fee_amount: u128) {
+        self.fee_amount.write(fee_amount);
+    }
+
+    #[abi(embed_v0)]
+    impl PoolImpl of IMockPrivacyPool<ContractState> {
+        fn get_fee_amount(self: @ContractState) -> u128 {
+            self.fee_amount.read()
+        }
+
+        fn apply_actions(ref self: ContractState) {}
+    }
+}

--- a/crates/paymaster-execution/src/execution/build.rs
+++ b/crates/paymaster-execution/src/execution/build.rs
@@ -370,7 +370,10 @@ impl PrivateTransaction {
 
         let total_fee_in_strk = estimated_fee_in_strk + Felt::from(self.pool_fee_amount);
 
-        let suggested_max_fee_in_strk = client.compute_max_fee_in_strk(total_fee_in_strk);
+        // Apply the max_fee multiplier only to the estimated gas fee (which can drift at execute time).
+        // The pool fee is a fixed amount in STRK read from the pool, so we only add the smaller
+        // provider overhead to cover STRK / gas-token price drift between build and execute.
+        let suggested_max_fee_in_strk = client.compute_max_fee_in_strk(estimated_fee_in_strk) + client.compute_paid_fee_in_strk(Felt::from(self.pool_fee_amount));
         let suggested_max_fee_in_gas_token = convert_strk_to_token(&token, suggested_max_fee_in_strk, true)?;
 
         let typed_data = if let Some(user_calls) = self.user_calls {
@@ -396,7 +399,7 @@ impl PrivateTransaction {
         // In sponsored mode the relayer covers gas but the user still pays the pool fee
         let fee_action_amount = if self.parameters.fee_mode().is_sponsored() {
             if self.pool_fee_amount > 0 {
-                let pool_fee_with_overhead = client.compute_max_fee_in_strk(Felt::from(self.pool_fee_amount));
+                let pool_fee_with_overhead = client.compute_paid_fee_in_strk(Felt::from(self.pool_fee_amount));
                 convert_strk_to_token(&token, pool_fee_with_overhead, true)?
             } else {
                 Felt::ZERO

--- a/crates/paymaster-execution/src/execution/execute.rs
+++ b/crates/paymaster-execution/src/execution/execute.rs
@@ -1,4 +1,5 @@
 use paymaster_prices::math::convert_strk_to_token;
+use paymaster_starknet::constants::Token;
 use paymaster_starknet::transaction::{
     parse_server_actions, CalldataBuilder, Calls, EstimatedCalls, ExecuteFromOutsideMessage, PrivateProofData, SequentialCalldataDecoder, ServerAction, TokenTransfer,
 };
@@ -397,6 +398,17 @@ impl ExecutableTransaction {
         Calls::new(calls)
     }
 
+    /// The privacy pool collects its fee in STRK via `transferFrom(forwarder, ...)`. The forwarder is
+    /// never paid in STRK — the user may be paying in a different gas token (USDC, etc.) — so the
+    /// relayer seeds the forwarder's STRK balance before the forwarder call. The relayer is later
+    /// reimbursed through the standard gas-tank → relayers STRK rebalancing cycle.
+    fn build_pool_fee_pretransfer_call(&self) -> Option<Call> {
+        if self.privacy_pool_fee_amount == 0 {
+            return None;
+        }
+        Some(TokenTransfer::new(Token::STRK_ADDRESS, self.forwarder, Felt::from(self.privacy_pool_fee_amount)).to_call())
+    }
+
     /// Validate and build the inner calls for a private transaction (optional execute_from_outside + apply_actions)
     fn build_private_inner_calls(&self, invoke: Option<&ExecutableInvokeParameters>, apply_action: &ExecutableApplyActionParameters) -> Result<Vec<Call>, Error> {
         let apply_call = &apply_action.apply_actions_call;
@@ -445,7 +457,12 @@ impl ExecutableTransaction {
                 .build(),
         };
 
-        Ok(Calls::new(vec![forwarder_call]))
+        let mut calls = Vec::with_capacity(2);
+        if let Some(pretransfer) = self.build_pool_fee_pretransfer_call() {
+            calls.push(pretransfer);
+        }
+        calls.push(forwarder_call);
+        Ok(Calls::new(calls))
     }
 
     /// Build calls for a gasless private transaction using `execute_private`
@@ -468,7 +485,12 @@ impl ExecutableTransaction {
                 .build(),
         };
 
-        Ok(Calls::new(vec![forwarder_call]))
+        let mut calls = Vec::with_capacity(2);
+        if let Some(pretransfer) = self.build_pool_fee_pretransfer_call() {
+            calls.push(pretransfer);
+        }
+        calls.push(forwarder_call);
+        Ok(Calls::new(calls))
     }
 
     fn build_deploy_call(&self) -> Option<Call> {


### PR DESCRIPTION
## Summary

Combined fix for three related bugs in the privacy-pool fee flow. Supersedes and closes #73, #74, #75.

For a private transaction with `pool_fee > 0`, the privacy pool's `apply_actions` collects its fee via `transferFrom(forwarder, fee_collector, fee)` in STRK. Today that call reverts, for three distinct reasons. Each commit fixes one.

### Commit 1 — Approve privacy pool to pull STRK fee in forwarder *(Cairo)*

The forwarder never grants the pool an allowance, so the pool's `transferFrom` reverts at the ERC20 allowance check.

- New `IPrivacyPool` dispatcher (`get_fee_amount` only) and a `MAX_POOL_FEE = 10_000 STRK` safety cap.
- New `approve_pool_fee` helper reads the pool address from the last call's `to`, queries the fee, asserts the cap, and approves the **pool** (not `fee_collector`) to pull the STRK.
- Wired into `execute_private` and `execute_private_sponsored`.
- Added `MockPrivacyPool` and end-to-end tests covering the approve flow and the fee-limit guard.

### Commit 2 — Apply only provider overhead to the privacy pool fee *(Rust)*

#72 applied `max_fee_multiplier` (~3x) to the pool fee, so users were asked to approve triple the amount they actually owed and hit "Insufficient ERC20 balance" on execute (observed: 192k → 513k wei USDC).

The pool fee is a fixed amount in STRK — it doesn't need the gas-volatility multiplier, only a small overhead for STRK / gas-token price drift between build and execute.

- Gas portion keeps `compute_max_fee_in_strk` (~3x).
- Pool portion switches to `compute_paid_fee_in_strk` (~`1 + provider_fee_overhead` ≈ 1.1x).

### Commit 3 — Pre-fund forwarder with STRK from relayer for privacy pool fee *(Rust)*

Even with the approve in place, when the user pays in a non-STRK gas token (USDC, etc.) the forwarder holds no STRK for the pool to pull.

The relayer already holds STRK (refilled by the gas-tank → relayers rebalancing), so we prepend `strk.transfer(forwarder, pool_fee_amount)` before the forwarder call in both `build_private_calls` and `build_private_sponsored_calls`. The relayer is reimbursed when the forwarder forwards the user's gas-token payment to the gas tank — the existing rebalancing later converts that back to STRK and tops the relayer up. No-op when `privacy_pool_fee_amount == 0`.

## Known edge case

When `gas_token == STRK`, the forwarder's `received >= gas_amount` assertion can under-count because the pool pulls STRK from the same balance the forwarder tracks. The non-STRK path (the reported USDC bug) works as intended; STRK-as-gas-token with pool fee would need either a forwarder-contract change or splitting the user deposit. Flagged as a follow-up — not blocking the USDC unblock.

## Test plan

- [x] `scarb build` in `contracts/`
- [x] `scarb test` — 17/17 Cairo tests passing, including a positive allowance test and a fee-limit-guard test
- [x] `cargo build -p paymaster-execution`
- [x] `cargo test -p paymaster-execution` — 33/33 passing
- [x] `cargo clippy -p paymaster-execution` — no new warnings
- [ ] Mainnet repro with `pool_fee_token = USDC` and `privacy_pool_fee_amount > 0`: confirm `apply_actions` no longer reverts, approve amount ≈ 1.1× pool fee (not ~2.66×), no "Insufficient ERC20 balance"
- [ ] Regression check with `privacy_pool_fee_amount = 0` (no extra pre-transfer call emitted, fee calc unchanged)
- [ ] Verify relayer STRK balance moves as expected and rebalancing tops it up