### PR TITLE
:bug: Fix Insufficient pool fee payment when gas_token == STRK

### DIFF
--- a/contracts/src/forwarder.cairo
+++ b/contracts/src/forwarder.cairo
@@ -108,8 +108,9 @@ pub mod Forwarder {
 
     // The last call of every private batch targets the privacy pool; approve the pool to pull
     // its STRK fee during `apply_actions`. The pool always collects fees in STRK, independent
-    // of the gas token the user is paying in.
-    fn approve_pool_fee(calls: @Array<Call>) {
+    // of the gas token the user is paying in. Returns the fee amount so callers can adjust the
+    // gas-token balance snapshot when gas_token == STRK (see execute_private*).
+    fn approve_pool_fee(calls: @Array<Call>) -> u256 {
         assert(calls.len() > 0, 'Empty calls');
         let last_call = calls.at(calls.len() - 1);
         let pool_address = *last_call.to;
@@ -120,6 +121,7 @@ pub mod Forwarder {
             let strk = IERC20Dispatcher { contract_address: STRK_TOKEN_ADDRESS.try_into().unwrap() };
             strk.approve(pool_address, fee_amount);
         }
+        fee_amount
     }
 
     #[abi(embed_v0)]
@@ -191,9 +193,20 @@ pub mod Forwarder {
 
             let contract_address = get_contract_address();
             let gas_token = IERC20Dispatcher { contract_address: gas_token_address };
-            let balance_before = gas_token.balanceOf(contract_address);
 
-            approve_pool_fee(@calls);
+            // Approve the pool to pull its STRK fee, and grab that fee amount.
+            let pool_fee = approve_pool_fee(@calls);
+
+            // When gas_token == STRK, the relayer pre-transferred `pool_fee` STRK to this forwarder
+            // immediately before this call (see paymaster-execution::build_pool_fee_pretransfer_call).
+            // The pool will pull that exact amount back during apply_actions, so it must NOT count
+            // toward `received` — otherwise the assertion below underestimates what the user paid.
+            let pretransferred: u256 = if gas_token_address == STRK_TOKEN_ADDRESS.try_into().unwrap() {
+                pool_fee
+            } else {
+                0_u256
+            };
+            let balance_before = gas_token.balanceOf(contract_address) - pretransferred;
 
             // Execute each call
             for call in calls {
@@ -224,16 +237,23 @@ pub mod Forwarder {
             assert(self.whitelist.is_whitelisted(caller), 'Caller is not whitelisted');
 
             let contract_address = get_contract_address();
-
-            // Snapshot balance before execution so we can verify the pool fee was actually paid
             let gas_token = IERC20Dispatcher { contract_address: gas_token_address };
-            let balance_before = if gas_amount > 0 {
-                gas_token.balanceOf(contract_address)
+
+            // Approve the pool to pull its STRK fee, and grab that fee amount.
+            let pool_fee = approve_pool_fee(@calls);
+
+            // Same offset as in execute_private: when gas_token == STRK, exclude the relayer's
+            // pre-transferred STRK from the pool-fee-payment snapshot.
+            let pretransferred: u256 = if gas_amount > 0 && gas_token_address == STRK_TOKEN_ADDRESS.try_into().unwrap() {
+                pool_fee
             } else {
                 0_u256
             };
-
-            approve_pool_fee(@calls);
+            let balance_before = if gas_amount > 0 {
+                gas_token.balanceOf(contract_address) - pretransferred
+            } else {
+                0_u256
+            };
 
             // Execute each call
             for call in calls {

--- a/crates/paymaster-execution/src/execution/build.rs
+++ b/crates/paymaster-execution/src/execution/build.rs
@@ -1,4 +1,5 @@
 use paymaster_prices::math::convert_strk_to_token;
+use paymaster_starknet::constants::Token;
 use paymaster_starknet::transaction::{Calls, ExecuteFromOutsideMessage, ExecuteFromOutsideParameters, PaymasterVersion, TokenTransfer};
 use paymaster_starknet::{ChainID, ContractAddress};
 use starknet::core::types::{BroadcastedTransaction, Felt, TypedData};
@@ -370,10 +371,19 @@ impl PrivateTransaction {
 
         let total_fee_in_strk = estimated_fee_in_strk + Felt::from(self.pool_fee_amount);
 
+        // The provider overhead on the pool fee covers STRK/gas-token price drift between build
+        // and execute. When the user pays the pool fee in STRK, there is no drift to cover, so we
+        // pass the raw pool fee through.
+        let pool_fee_with_overhead = if gas_token == Token::STRK_ADDRESS {
+            Felt::from(self.pool_fee_amount)
+        } else {
+            client.compute_paid_fee_in_strk(Felt::from(self.pool_fee_amount))
+        };
+
         // Apply the max_fee multiplier only to the estimated gas fee (which can drift at execute time).
         // The pool fee is a fixed amount in STRK read from the pool, so we only add the smaller
-        // provider overhead to cover STRK / gas-token price drift between build and execute.
-        let suggested_max_fee_in_strk = client.compute_max_fee_in_strk(estimated_fee_in_strk) + client.compute_paid_fee_in_strk(Felt::from(self.pool_fee_amount));
+        // provider overhead (or none, when gas_token == STRK) on top.
+        let suggested_max_fee_in_strk = client.compute_max_fee_in_strk(estimated_fee_in_strk) + pool_fee_with_overhead;
         let suggested_max_fee_in_gas_token = convert_strk_to_token(&token, suggested_max_fee_in_strk, true)?;
 
         let typed_data = if let Some(user_calls) = self.user_calls {
@@ -396,10 +406,10 @@ impl PrivateTransaction {
             None
         };
 
-        // In sponsored mode the relayer covers gas but the user still pays the pool fee
+        // In sponsored mode the relayer covers gas but the user still pays the pool fee. Reuse the
+        // overhead-aware amount computed above (no overhead when gas_token == STRK).
         let fee_action_amount = if self.parameters.fee_mode().is_sponsored() {
             if self.pool_fee_amount > 0 {
-                let pool_fee_with_overhead = client.compute_paid_fee_in_strk(Felt::from(self.pool_fee_amount));
                 convert_strk_to_token(&token, pool_fee_with_overhead, true)?
             } else {
                 Felt::ZERO


### PR DESCRIPTION
## Summary

- **Forwarder fix** (`contracts/src/forwarder.cairo`): when the user pays the privacy pool fee in STRK, the forwarder's `balance_before` snapshot already includes the relayer's pre-transferred STRK. The pool's `transferFrom` then pulls that exact amount back, so `received` ends up `pool_fee` short of `gas_amount` and the assertion reverts with `Insufficient pool fee payment`. Fix: when `gas_token_address == STRK_ADDRESS`, subtract the pool fee (now returned by `approve_pool_fee`) from `balance_before`. Behaviour for non-STRK gas tokens is unchanged.
- **Skip provider overhead on STRK pool fees** (`build.rs`): the `provider_fee_overhead` on the pool fee covers STRK / gas-token price drift between build and execute. When the gas token IS STRK there's no drift to cover — pass the raw `pool_fee_amount` through. Saves the user ~0.6 STRK per private tx on mainnet.

## Why `gas_token == STRK` was the only broken combo

Trace for STRK fee (mainnet, pool_fee = 4 STRK, user signs 4.6 STRK transfer):
1. Relayer call #1: `STRK.transfer(forwarder, 4)` → forwarder = X + 4
2. `execute_private_sponsored` entry: `balance_before = X + 4`
3. Pool's `apply_actions`: user TransferTo +4.6 STRK, pool `transferFrom` -4 STRK
4. `balance_after = X + 4.6`, `received = 0.6`, `assert(0.6 >= 4.6)` → revert

For USDC the pretransfer (in STRK) and the pool's pull (in STRK) don't touch the snapshot (which is in USDC), so `received` correctly equals what the user paid.

Reported by tester on `starknet.paymaster.avnu.fi`: USDC withdraw succeeded (`0x48ac1406…`), STRK withdraw reverted with `Insufficient pool fee payment`.

## Test plan
- [x] `scarb test` passes (16/16) — existing pool-fee tests still cover the non-STRK path and the safety cap.
- [x] `cargo build` workspace clean.
- [x] `cargo test -p paymaster-execution` passes (33/33).
- [ ] Redeploy upgraded forwarder on sepolia, run the tester's STRK withdraw scenario → expect success.
- [ ] Same on mainnet after sepolia validation.

## Notes

- Cairo unit tests for the new `gas_token == STRK` branch were not added: it requires a mock STRK at the canonical address, which would force a setter on the forwarder to override `STRK_ADDRESS`. We're leaving STRK as a const and validating end-to-end on sepolia/mainnet instead.
- Forwarder is upgrade-compatible: no new storage slots, no constructor signature change.