### PR TITLE
:zap: Speed up paymaster_getSupportedTokens fanout

### DIFF
--- a/crates/paymaster-prices/src/lib.rs
+++ b/crates/paymaster-prices/src/lib.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 
 use crate::avnu::{AVNUPriceClientConfiguration, AVNUPriceOracle};
 use paymaster_common::concurrency::ConcurrentExecutor;
+use paymaster_starknet::constants::Token;
 use serde::{Deserialize, Serialize};
 use starknet::core::types::Felt;
 use thiserror::Error;
@@ -120,7 +121,11 @@ impl Client {
     }
 
     pub async fn fetch_tokens(&self, tokens: &HashSet<Felt>) -> Vec<Result<TokenPrice, Error>> {
-        let mut executor = ConcurrentExecutor::new(self.clone(), 8);
+        // Warm the STRK price cache once so concurrent workers below all hit the cache
+        // instead of each issuing their own STRK fetch.
+        let _ = self.fetch_token(Token::STRK_ADDRESS).await;
+
+        let mut executor = ConcurrentExecutor::new(self.clone(), 32);
         for token in tokens.iter().cloned() {
             executor.register(task!(|context| { context.fetch_token(token).await }));
         }


### PR DESCRIPTION
## Summary

- Bump the `Client::fetch_tokens` concurrency from **8 → 32**, so all supported tokens fetch in a single round instead of 4 sequential rounds (with 32 supported tokens).
- Pre-fetch the STRK price once before the fanout to warm the cache, avoiding 32 concurrent workers each issuing a redundant STRK call on cold start.

## Why

`paymaster_getSupportedTokens` was observed at ~2s p95. Profiling showed:

- ~32 supported tokens × concurrency 8 = 4 sequential rounds
- Each `fetch_token` does 2 HTTP calls (STRK + token); on cold cache the STRK call gets duplicated across all parallel workers in the first round

A bench against the AVNU price API confirmed that 32 parallel calls finish in ~one round-trip instead of stacking 4 of them. Expected p95: ~500-700ms.

## Test plan

- [ ] `cargo build -p paymaster-prices` passes
- [ ] `cargo test -p paymaster-prices` passes
- [ ] Run the service locally and call `paymaster_getSupportedTokens` — confirm latency drops from ~2s to <1s
- [ ] Watch Grafana `paymaster_rpc_request_duration_milliseconds{method="get_supported_tokens_endpoint"}` after deploy