### PR TITLE
:bug: Skip overhead cache when account contract is not yet deployed

### DIFF
--- a/crates/paymaster-execution/src/execution/fee/overhead.rs
+++ b/crates/paymaster-execution/src/execution/fee/overhead.rs
@@ -25,8 +25,8 @@ impl Mul<ValidationGasOverhead> for BlockGasPrice {
 }
 
 impl ValidationGasOverhead {
-    /// No additional gos
-    fn none() -> Self {
+    /// No additional gas
+    pub fn none() -> Self {
         Self::default()
     }
 
@@ -39,7 +39,17 @@ impl ValidationGasOverhead {
         }
     }
 
-    /// Returns the overhead approximation given the [`user`] address
+    fn from_get_signers_response(response: &[Felt]) -> Self {
+        if response.len() > 4 {
+            Self::braavos()
+        } else {
+            Self::none()
+        }
+    }
+
+    /// Returns the overhead approximation given the [`user`] address. An `Err` means the
+    /// detection is not authoritative (contract not deployed yet, transient RPC error)
+    /// and the caller should not cache the result.
     pub async fn fetch(client: &Client, user: ContractAddress) -> Result<Self, Error> {
         let call = FunctionCall {
             contract_address: user,
@@ -48,12 +58,45 @@ impl ValidationGasOverhead {
         };
 
         match client.call(&call).await {
-            Ok(response) if response.len() > 4 => Ok(Self::braavos()),
-            Ok(_) => Ok(Self::none()),
-            Err(e) => {
-                tracing::debug!(user = %user.to_fixed_hex_string(), error = %e, "get_signers failed (expected for non-Braavos)");
-                Ok(Self::none())
-            },
+            Ok(response) => Ok(Self::from_get_signers_response(&response)),
+            Err(paymaster_starknet::Error::Execution(_)) | Err(paymaster_starknet::Error::Contract(_)) => Ok(Self::none()),
+            Err(e) => Err(e.into()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_get_signers_response_classic_braavos_4_felts_returns_none() {
+        let response = vec![
+            felt!("0x1"),
+            felt!("0x14ffa4f8f8770236d284eee22b52120102e22af8c9ca1a045084be9b1e7d1b9"),
+            Felt::ZERO,
+            Felt::ZERO,
+        ];
+        let overhead = ValidationGasOverhead::from_get_signers_response(&response);
+        assert_eq!(overhead.l2_gas, Felt::ZERO);
+    }
+
+    #[test]
+    fn from_get_signers_response_braavos_passkey_5_felts_returns_braavos() {
+        let response = vec![
+            felt!("0x1"),
+            felt!("0x4221c76ba6e0e6b0c9b51bf74c9bd84ca40c33049443f7b3700c982f3348163"),
+            felt!("0x1"),
+            felt!("0x4939ff2d144c912b3bd7906928101c1a1c13a342911216dce9192d2114ae71"),
+            Felt::ZERO,
+        ];
+        let overhead = ValidationGasOverhead::from_get_signers_response(&response);
+        assert_eq!(overhead.l2_gas, felt!("0x02c7ab80"));
+    }
+
+    #[test]
+    fn from_get_signers_response_empty_returns_none() {
+        let overhead = ValidationGasOverhead::from_get_signers_response(&[]);
+        assert_eq!(overhead.l2_gas, Felt::ZERO);
     }
 }

--- a/crates/paymaster-execution/src/starknet/mod.rs
+++ b/crates/paymaster-execution/src/starknet/mod.rs
@@ -104,10 +104,13 @@ impl Client {
             return Ok(value);
         }
 
-        let overhead = ValidationGasOverhead::fetch(self, user).await?;
-        self.cache_overhead.insert(user, overhead);
-
-        Ok(overhead)
+        match ValidationGasOverhead::fetch(self, user).await {
+            Ok(overhead) => {
+                self.cache_overhead.insert(user, overhead);
+                Ok(overhead)
+            },
+            Err(_) => Ok(ValidationGasOverhead::none()),
+        }
     }
 
     /// Fetch the current block gas price. This function relies on a cache that expires every 10s so


### PR DESCRIPTION
## Summary

`ValidationGasOverhead::fetch` used to convert every error from `client.call(get_signers)` into `Ok(Self::none())`, and `resolve_gas_overhead` cached every result indefinitely. As a side effect, any address queried while its contract did not yet exist — typically during a `deploy_and_invoke` flow that deploys the wallet in the same transaction it is estimating — got permanently marked as "no overhead" in the cache. Once the wallet was actually deployed and the user did follow-up sponsored invokes, the cached `none()` was returned instead of the Braavos overhead, the resource bound on `l2_gas` was set ~5x too low, and Braavos passkey transactions reverted with `Insufficient max L2Gas: max amount: 9422157, actual used: 48940800`.

This PR distinguishes error variants in `fetch`:

- **successful response** → cache (Braavos or none, based on shape)
- **contract-level execution error** (account exists but does not expose `get_signers`, e.g. Argent / OZ / custom accounts) → cache as `none()`
- **`ContractNotFound`** (wallet not yet deployed — the case behind this bug) → return `none()` for the current request but **skip the cache** so the next request retries the detection once the wallet is on-chain
- **any other transient RPC error** (timeout, rate-limit, internal, ...) → same as `ContractNotFound`: do not cache

Also extracts the response-shape classification into a pure function (`from_get_signers_response`) and adds unit tests covering the on-chain shapes observed for a classic Braavos (4 felts) and a Braavos with a passkey/secp256r1 signer (5 felts).

## Diagnosis trail (for reference)

Confirmed on tx `0x4b7a1cb5215c43c9f60735b1361b9ad2e43f2f446a968e7de152f2edf82baee` (mainnet, block 9680273):

- `resource_bounds.l2_gas.max_amount = 0x8fc54d = 9 422 157` on-chain
- Back-computing through the multipliers (`/1.5` estimate, `/1.15` provider) yields a raw simulator `l2_gas_consumed ≈ 5.46M` — i.e. no Braavos overhead was added to the recomputed fee
- If the 46.64M Braavos overhead had been applied, the resource bound would have been ~90M (more than enough for the ~48.9M actually consumed)
- Service logs around the wallet's deployment confirm `get_signers` returned `ContractNotFound` during `paymaster_buildTransaction` and `paymaster_executeTransaction` of the `deploy_and_invoke`, which got swallowed into `Ok(Self::none())` and cached

## Scope

This PR fixes the **cache-poisoning** dimension of the bug, which is the one observed on the reported transaction (the wallet was queried before deployment, the cached `none()` then persisted for the subsequent sponsored invoke).

It does **not** address the related case where the failing transaction is itself the `deploy_and_invoke` of a Braavos passkey wallet (`get_signers` is fundamentally unreachable at simulation time because the wallet is being deployed in the same transaction). That requires reading the account type from the `deployment.class_hash` / `sigdata`, and will be handled in a follow-up.

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo clippy -p paymaster-execution` passes
- [x] `cargo test -p paymaster-execution --lib` — all 36 existing tests pass + 3 new ones cover the response-shape classification
- [ ] Manual confirmation against a Braavos passkey sponsored invoke on mainnet after deploy (requires running the patched service against the reported failure scenario)