### PR TITLE
:bug: Cap declared L2 gas bound at the sequencer gateway limit

### DIFF
--- a/crates/paymaster-cli/src/command/balance/mod.rs
+++ b/crates/paymaster-cli/src/command/balance/mod.rs
@@ -65,6 +65,7 @@ pub async fn command_balances(params: BalancesCommandParameters) -> Result<(), E
         chain_id,
         fallbacks: vec![],
         timeout: 10,
+        max_l2_gas_amount: paymaster_starknet::default_max_l2_gas_amount(),
     });
 
     // Display relayers balances

--- a/crates/paymaster-cli/src/command/empty/mod.rs
+++ b/crates/paymaster-cli/src/command/empty/mod.rs
@@ -191,6 +191,7 @@ pub async fn command_empty_paymaster(params: EmptyPaymasterParameters) -> Result
         chain_id: chain_id.clone(),
         fallbacks: vec![],
         timeout: configuration.starknet.timeout,
+        max_l2_gas_amount: paymaster_starknet::default_max_l2_gas_amount(),
     });
 
     empty_paymaster_core(&starknet, &configuration, params.master_address, params.master_pk, params.force).await?;

--- a/crates/paymaster-cli/src/command/relayer/deploy.rs
+++ b/crates/paymaster-cli/src/command/relayer/deploy.rs
@@ -65,6 +65,7 @@ pub async fn command_relayers_deploy(params: RelayersDeployCommandParameters) ->
         chain_id,
         fallbacks: vec![],
         timeout: configuration.starknet.timeout,
+        max_l2_gas_amount: paymaster_starknet::default_max_l2_gas_amount(),
     });
 
     // Assert the balance of master is greater than the amount of STRK needed for the deployment

--- a/crates/paymaster-cli/src/command/relayer/rebalance.rs
+++ b/crates/paymaster-cli/src/command/relayer/rebalance.rs
@@ -56,6 +56,7 @@ pub async fn command_relayers_rebalance(params: RelayersRebalanceCommandParamete
         chain_id: chain_id.clone(),
         fallbacks: vec![],
         timeout: configuration.starknet.timeout,
+        max_l2_gas_amount: paymaster_starknet::default_max_l2_gas_amount(),
     });
 
     // How much STRK to refund the gas tank with from the master account

--- a/crates/paymaster-cli/src/command/setup/mod.rs
+++ b/crates/paymaster-cli/src/command/setup/mod.rs
@@ -162,6 +162,7 @@ pub async fn deploy_paymaster_core(params: SetupParameters, skip_user_confirmati
         chain_id,
         fallbacks: vec![],
         timeout: 10,
+        max_l2_gas_amount: paymaster_starknet::default_max_l2_gas_amount(),
     });
 
     // Check that the initial funding is enough for rebalancing to work properly
@@ -236,6 +237,7 @@ pub async fn deploy_paymaster_core(params: SetupParameters, skip_user_confirmati
             chain_id,
             fallbacks: vec![],
             timeout: params.rpc_timeout,
+            max_l2_gas_amount: paymaster_starknet::default_max_l2_gas_amount(),
         },
         rpc: RPCConfiguration { port: params.rpc_port },
         prometheus: None,

--- a/crates/paymaster-execution/src/error.rs
+++ b/crates/paymaster-execution/src/error.rs
@@ -41,6 +41,9 @@ pub enum Error {
     #[error("pool fee amount too low. Expected at least {0}")]
     PoolFeeTooLow(String),
 
+    #[error("required L2 gas amount exceeds the maximum allowed by the sequencer: {0}")]
+    MaxL2GasAmountExceeded(String),
+
     #[error("execution error {0}")]
     Execution(String),
 }
@@ -49,6 +52,7 @@ impl From<paymaster_starknet::Error> for Error {
     fn from(value: paymaster_starknet::Error) -> Self {
         match value {
             paymaster_starknet::Error::InvalidNonce(_) => Self::InvalidVersion,
+            e @ paymaster_starknet::Error::MaxL2GasAmountExceeded { .. } => Self::MaxL2GasAmountExceeded(e.to_string()),
             e => Self::Execution(e.to_string()),
         }
     }

--- a/crates/paymaster-execution/src/execution/execute.rs
+++ b/crates/paymaster-execution/src/execution/execute.rs
@@ -261,6 +261,10 @@ impl ExecutableTransaction {
             })?;
         let final_fee_estimate = fee_estimate.update_overall_fee(paid_fee_in_strk);
 
+        // Reject here (before locking a relayer and broadcasting) when the L2 gas bound cannot fit
+        // under the sequencer cap, so the typed MaxL2GasAmountExceeded error reaches the client.
+        final_fee_estimate.check_l2_gas_within_cap()?;
+
         // Validate pool fee transfer for private sponsored transactions
         if self.privacy_pool_fee_amount > 0 {
             if let Some(apply_action) = match &self.transaction {
@@ -318,6 +322,10 @@ impl ExecutableTransaction {
             })?;
         let final_fee_estimate = fee_estimate.update_overall_fee(paid_fee_in_strk);
 
+        // Reject here (before locking a relayer and broadcasting) when the L2 gas bound cannot fit
+        // under the sequencer cap, so the typed MaxL2GasAmountExceeded error reaches the client.
+        final_fee_estimate.check_l2_gas_within_cap()?;
+
         let token_price = client.price.fetch_token(transfer.token()).await?;
         let paid_fee_in_token = convert_strk_to_token(&token_price, paid_fee_in_strk, true)?;
 
@@ -349,6 +357,11 @@ impl ExecutableTransaction {
 
         let gas_fee_in_strk = self.compute_paid_fee(client, Felt::from(fee_estimate.overall_fee)).await?;
         let gas_estimate = fee_estimate.update_overall_fee(gas_fee_in_strk);
+
+        // Reject here (before locking a relayer and broadcasting) when the L2 gas bound cannot fit
+        // under the sequencer cap, so the typed MaxL2GasAmountExceeded error reaches the client.
+        gas_estimate.check_l2_gas_within_cap()?;
+
         let required_fee_in_strk = gas_fee_in_strk + Felt::from(self.privacy_pool_fee_amount);
 
         let token_price = client.price.fetch_token(transfer.token()).await?;

--- a/crates/paymaster-execution/src/lib.rs
+++ b/crates/paymaster-execution/src/lib.rs
@@ -81,6 +81,7 @@ pub struct Client {
 
     max_fee_multiplier: f32,
     provider_fee_multiplier: f32,
+    max_l2_gas_amount: u64,
 
     estimate_account: StarknetAccount,
     relayers: RelayerManager,
@@ -97,6 +98,7 @@ impl Client {
 
             max_fee_multiplier: configuration.max_fee_multiplier,
             provider_fee_multiplier: 1.0 + configuration.provider_fee_overhead,
+            max_l2_gas_amount: configuration.starknet.max_l2_gas_amount,
 
             estimate_account: Starknet::new(&configuration.starknet).initialize_account(&configuration.estimate_account),
             relayers: RelayerManager::new(&configuration.clone().into()),
@@ -159,7 +161,7 @@ impl Client {
         let tip = self.get_tip(tip).await?;
         let result = calls.estimate(&self.estimate_account, Some(tip)).await?;
 
-        Ok(result)
+        Ok(result.with_max_l2_gas_amount(self.max_l2_gas_amount))
     }
 
     /// Estimate gas for privacy transactions using real fee estimation with proof data.
@@ -167,7 +169,7 @@ impl Client {
         let tip = self.get_tip(tip).await?;
         let result = calls.estimate_with_proof(&self.estimate_account, Some(tip), proof_data).await?;
 
-        Ok(result)
+        Ok(result.with_max_l2_gas_amount(self.max_l2_gas_amount))
     }
 
     /// Get the tip value given a priority

--- a/crates/paymaster-prices/src/avnu/mod.rs
+++ b/crates/paymaster-prices/src/avnu/mod.rs
@@ -149,6 +149,7 @@ mod tests {
                 chain_id: ChainID::Sepolia,
                 timeout: 10,
                 fallbacks: vec![],
+                max_l2_gas_amount: paymaster_starknet::default_max_l2_gas_amount(),
             },
         });
 

--- a/crates/paymaster-prices/src/coingecko/mod.rs
+++ b/crates/paymaster-prices/src/coingecko/mod.rs
@@ -189,6 +189,7 @@ mod tests {
                 chain_id: ChainID::Mainnet,
                 timeout: 10,
                 fallbacks: vec![],
+                max_l2_gas_amount: paymaster_starknet::default_max_l2_gas_amount(),
             },
         });
 

--- a/crates/paymaster-relayer/src/lib.rs
+++ b/crates/paymaster-relayer/src/lib.rs
@@ -211,6 +211,7 @@ mod tests {
                     chain_id: ChainID::Sepolia,
                     timeout: 10,
                     fallbacks: vec![],
+                    max_l2_gas_amount: paymaster_starknet::default_max_l2_gas_amount(),
                 },
                 supported_tokens: HashSet::from([Token::usdc(&ChainID::Sepolia).address]),
                 gas_tank: StarknetAccountConfiguration {

--- a/crates/paymaster-relayer/src/lock/seggregated/mod.rs
+++ b/crates/paymaster-relayer/src/lock/seggregated/mod.rs
@@ -153,6 +153,7 @@ mod tests {
                 chain_id: ChainID::Sepolia,
                 fallbacks: vec![],
                 timeout: 10,
+                max_l2_gas_amount: paymaster_starknet::default_max_l2_gas_amount(),
             },
             supported_tokens: HashSet::from([Token::usdc(&ChainID::Sepolia).address]),
             gas_tank: StarknetAccountConfiguration {

--- a/crates/paymaster-relayer/src/rebalancing/mod.rs
+++ b/crates/paymaster-relayer/src/rebalancing/mod.rs
@@ -585,6 +585,7 @@ mod rebalancing_tests {
                 endpoint: "http://localhost:5050".to_string(),
                 fallbacks: vec![],
                 timeout: 10,
+                max_l2_gas_amount: paymaster_starknet::default_max_l2_gas_amount(),
             },
             supported_tokens: HashSet::from([Token::usdc(&ChainID::Sepolia).address]),
             relayers: RelayersConfiguration {

--- a/crates/paymaster-rpc/src/lib.rs
+++ b/crates/paymaster-rpc/src/lib.rs
@@ -105,6 +105,9 @@ pub enum Error {
     #[error("sponsored_private mode requires a private transaction")]
     SponsoredPrivateRequiresPrivacy,
 
+    #[error("max L2 gas amount exceeded: {0}")]
+    MaxL2GasAmountExceeded(String),
+
     #[error("{0:?}")]
     Execution(ContractExecutionError),
 }
@@ -141,6 +144,7 @@ impl From<PaymasterExecutionError> for Error {
             PaymasterExecutionError::CalldataParsing(_) => Self::CalldataParsing,
             PaymasterExecutionError::MaxAmountTooLow(_) => Self::MaxAmountTooLow,
             PaymasterExecutionError::PoolFeeTooLow(_) => Self::PoolFeeTooLow,
+            PaymasterExecutionError::MaxL2GasAmountExceeded(msg) => Self::MaxL2GasAmountExceeded(msg),
             other => Self::Execution(ContractExecutionError::Message(other.to_string())),
         }
     }
@@ -167,6 +171,7 @@ impl<'a> From<Error> for ErrorObject<'a> {
             Error::CalldataParsing => ErrorObject::borrowed(166, "An error occurred (CALLDATA_PARSING)", None),
             Error::PoolFeeTooLow => ErrorObject::borrowed(167, "An error occurred (POOL_FEE_TOO_LOW)", None),
             Error::SponsoredPrivateRequiresPrivacy => ErrorObject::borrowed(168, "An error occurred (SPONSORED_PRIVATE_REQUIRES_PRIVACY)", None),
+            Error::MaxL2GasAmountExceeded(msg) => ErrorObject::owned(169, "An error occurred (MAX_L2_GAS_AMOUNT_EXCEEDED)", Some(msg)),
             Error::Execution(e) => ErrorObject::owned(156, "An error occurred (TRANSACTION_EXECUTION_ERROR)", Some(ExecutionError { execution_error: e })),
             Error::BlacklistedCalls => ErrorObject::owned(163, "An error occurred (UNKNOWN_ERROR)", Some(Error::BlacklistedCalls.to_string())),
             Error::ServiceNotAvailable => ErrorObject::owned(163, "An error occurred (UNKNOWN_ERROR)", Some(Error::ServiceNotAvailable.to_string())),

--- a/crates/paymaster-starknet/src/lib.rs
+++ b/crates/paymaster-starknet/src/lib.rs
@@ -115,6 +115,9 @@ pub enum Error {
 
     #[error("starknet error {0}")]
     ValidationFailure(String),
+
+    #[error("required L2 gas amount {required} exceeds the maximum allowed by the sequencer {max}")]
+    MaxL2GasAmountExceeded { required: u64, max: u64 },
 }
 
 impl From<ProviderError> for Error {
@@ -151,6 +154,12 @@ impl<T: Display + Debug> From<AccountError<T>> for Error {
     }
 }
 
+/// Default for [`Configuration::max_l2_gas_amount`]. Kept as a function so it can be used as a serde
+/// default for configs that omit the field.
+pub fn default_max_l2_gas_amount() -> u64 {
+    transaction::DEFAULT_MAX_L2_GAS_AMOUNT
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Configuration {
     pub chain_id: ChainID,
@@ -159,6 +168,12 @@ pub struct Configuration {
 
     #[serde(default)]
     pub fallbacks: Vec<String>,
+
+    /// Maximum L2 gas amount the paymaster will declare as a transaction bound. Mirrors the Starknet
+    /// sequencer gateway `max_l2_gas_amount` (minus a safety margin) and is configurable since the
+    /// sequencer value may change over time.
+    #[serde(default = "default_max_l2_gas_amount")]
+    pub max_l2_gas_amount: u64,
 }
 
 #[derive(Clone)]

--- a/crates/paymaster-starknet/src/testing/mod.rs
+++ b/crates/paymaster-starknet/src/testing/mod.rs
@@ -75,6 +75,7 @@ impl TestEnvironment {
             timeout: 10,
             endpoint,
             fallbacks: vec![],
+            max_l2_gas_amount: crate::default_max_l2_gas_amount(),
         };
 
         Self {

--- a/crates/paymaster-starknet/src/transaction/call/mod.rs
+++ b/crates/paymaster-starknet/src/transaction/call/mod.rs
@@ -196,7 +196,18 @@ impl EstimatedCalls {
         self.estimate.clone()
     }
 
+    /// Override the maximum L2 gas amount the declared gas bound will be capped to. See
+    /// [`TransactionGasEstimate::with_max_l2_gas_amount`].
+    pub fn with_max_l2_gas_amount(mut self, max_l2_gas_amount: u64) -> Self {
+        self.estimate = self.estimate.with_max_l2_gas_amount(max_l2_gas_amount);
+        self
+    }
+
     pub async fn execute(&self, account: &StarknetAccount, nonce: Felt) -> Result<InvokeTransactionResult, Error> {
+        // Reject before broadcast when the transaction cannot fit under the sequencer L2 gas cap, so we
+        // surface a clear error instead of a paid out-of-gas revert.
+        self.estimate.check_l2_gas_within_cap()?;
+
         let mut execution = account
             .execute_v3(self.calls.to_vec())
             .nonce(nonce)

--- a/crates/paymaster-starknet/src/transaction/gas.rs
+++ b/crates/paymaster-starknet/src/transaction/gas.rs
@@ -2,6 +2,20 @@ use starknet::core::types::{FeeEstimate, Felt};
 
 use crate::Error;
 
+/// Default upper bound (in L2 gas units) the paymaster will ever declare as `max_l2_gas_amount` on a
+/// transaction. Set to exactly the Starknet sequencer gateway `max_l2_gas_amount` on mainnet: the gateway
+/// rejects, during stateless validation (before broadcast), any transaction whose declared L2 gas amount
+/// is *strictly greater* (`>`) than this value, so declaring exactly it is accepted. Capping the padded
+/// estimate here keeps a heavy but legitimate transaction from being rejected purely because of the
+/// gas-bound padding multiplier. Configurable per network since the sequencer value may change over time.
+pub const DEFAULT_MAX_L2_GAS_AMOUNT: u64 = 1_200_000_000;
+
+/// Safety margin applied to the *actual* estimated L2 gas when deciding whether a transaction can safely
+/// fit under the cap. If the estimate times this margin already exceeds the cap, capping the declared
+/// bound would leave no headroom and the transaction would almost certainly revert out-of-gas, so we
+/// reject it early instead of wasting relayer gas.
+const L2_GAS_CAP_SAFETY_MULTIPLIER: f64 = 1.1;
+
 #[derive(Debug, Clone)]
 pub struct TransactionGasEstimate {
     pub overall_fee: u128,
@@ -14,6 +28,7 @@ pub struct TransactionGasEstimate {
     l1_data_gas_price: u128,
     gas_estimate_multiplier: f64,
     gas_price_estimate_multiplier: f64,
+    max_l2_gas_amount: u64,
 }
 
 impl TransactionGasEstimate {
@@ -29,7 +44,16 @@ impl TransactionGasEstimate {
             tip,
             gas_estimate_multiplier: 1.5,
             gas_price_estimate_multiplier: 1.5,
+            max_l2_gas_amount: DEFAULT_MAX_L2_GAS_AMOUNT,
         }
+    }
+
+    /// Override the maximum L2 gas amount the paymaster is willing to declare as a bound. This mirrors
+    /// the Starknet sequencer gateway `max_l2_gas_amount` (minus a safety margin) and is configurable
+    /// per network.
+    pub fn with_max_l2_gas_amount(mut self, max_l2_gas_amount: u64) -> Self {
+        self.max_l2_gas_amount = max_l2_gas_amount;
+        self
     }
 
     pub fn update_overall_fee(self, overall_fee: Felt) -> Self {
@@ -53,6 +77,7 @@ impl TransactionGasEstimate {
             l1_data_gas_consumed: self.l1_data_gas_consumed,
             gas_estimate_multiplier: self.gas_estimate_multiplier,
             gas_price_estimate_multiplier: self.gas_price_estimate_multiplier,
+            max_l2_gas_amount: self.max_l2_gas_amount,
         }
     }
 
@@ -60,12 +85,32 @@ impl TransactionGasEstimate {
         self.tip
     }
 
+    /// Ensure the transaction can be declared with enough L2 gas headroom to fit under the sequencer
+    /// cap. Returns an error when even the bare estimate (plus a small safety margin) exceeds the cap,
+    /// since capping the declared bound in that case would lead to an out-of-gas revert and waste
+    /// relayer gas. Capping happens in [`Self::l2_gas_consumed`]; this guards the case capping cannot
+    /// save.
+    pub fn check_l2_gas_within_cap(&self) -> Result<(), Error> {
+        let required = (self.l2_gas_consumed as f64 * L2_GAS_CAP_SAFETY_MULTIPLIER) as u64;
+        if required > self.max_l2_gas_amount {
+            return Err(Error::MaxL2GasAmountExceeded {
+                required,
+                max: self.max_l2_gas_amount,
+            });
+        }
+
+        Ok(())
+    }
+
     pub fn l1_gas_consumed(&self) -> u64 {
         ((self.l1_gas_consumed as f64) * self.gas_estimate_multiplier) as u64
     }
 
     pub fn l2_gas_consumed(&self) -> u64 {
-        ((self.l2_gas_consumed as f64) * self.gas_estimate_multiplier) as u64
+        // Cap the declared L2 gas bound at `max_l2_gas_amount`: the padded estimate (raw * 1.5) can
+        // exceed the sequencer gateway limit and get the transaction rejected before broadcast, even
+        // though it only consumes a fraction of it. L1 gas / L1 data gas keep their full padding.
+        ((self.l2_gas_consumed as f64 * self.gas_estimate_multiplier) as u64).min(self.max_l2_gas_amount)
     }
 
     pub fn l1_data_gas_consumed(&self) -> u64 {
@@ -91,5 +136,66 @@ impl TransactionGasEstimate {
             ((TryInto::<u64>::try_into(self.l1_data_gas_price).map_err(|_| Error::Internal("Fee out of range".to_string()))? as f64) * self.gas_price_estimate_multiplier)
                 as u128,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use starknet::core::types::FeeEstimate;
+
+    use super::*;
+
+    fn estimate_with_l2_gas(l2_gas_consumed: u64) -> TransactionGasEstimate {
+        TransactionGasEstimate::new(
+            FeeEstimate {
+                l1_gas_consumed: 0,
+                l1_gas_price: 1,
+                l2_gas_consumed,
+                l2_gas_price: 1,
+                l1_data_gas_consumed: 0,
+                l1_data_gas_price: 1,
+                overall_fee: l2_gas_consumed as u128,
+            },
+            0,
+        )
+    }
+
+    #[test]
+    fn pads_l2_gas_by_multiplier_when_below_cap() {
+        // 100M raw -> 150M declared bound, well under the cap; nothing is clamped.
+        let estimate = estimate_with_l2_gas(100_000_000);
+        assert_eq!(estimate.l2_gas_consumed(), 150_000_000);
+        assert!(estimate.check_l2_gas_within_cap().is_ok());
+    }
+
+    #[test]
+    fn caps_l2_gas_bound_when_padding_exceeds_cap() {
+        // 900M raw -> 1.35B padded -> clamped to the 1.15B cap. The tx still fits (900M * 1.1 <= cap).
+        let estimate = estimate_with_l2_gas(900_000_000).with_max_l2_gas_amount(DEFAULT_MAX_L2_GAS_AMOUNT);
+        assert_eq!(estimate.l2_gas_consumed(), DEFAULT_MAX_L2_GAS_AMOUNT);
+        assert!(estimate.check_l2_gas_within_cap().is_ok());
+    }
+
+    #[test]
+    fn rejects_early_when_estimate_does_not_fit_under_cap() {
+        // 1.1B raw -> 1.1B * 1.1 = 1.21B > 1.15B cap: capping cannot give headroom, reject before broadcast.
+        let estimate = estimate_with_l2_gas(1_100_000_000).with_max_l2_gas_amount(DEFAULT_MAX_L2_GAS_AMOUNT);
+        assert!(matches!(estimate.check_l2_gas_within_cap(), Err(Error::MaxL2GasAmountExceeded { .. })));
+    }
+
+    #[test]
+    fn applies_custom_cap_override() {
+        // The cap is configurable: a lower override clamps the declared bound accordingly.
+        let estimate = estimate_with_l2_gas(100_000_000).with_max_l2_gas_amount(120_000_000);
+        assert_eq!(estimate.l2_gas_consumed(), 120_000_000);
+    }
+
+    #[test]
+    fn cap_is_preserved_through_update_overall_fee() {
+        // The cap field must survive the re-derivation done at execute time.
+        let estimate = estimate_with_l2_gas(900_000_000)
+            .with_max_l2_gas_amount(DEFAULT_MAX_L2_GAS_AMOUNT)
+            .update_overall_fee(Felt::from(900_000_000u64));
+        assert_eq!(estimate.l2_gas_consumed(), DEFAULT_MAX_L2_GAS_AMOUNT);
     }
 }

--- a/crates/paymaster-starknet/src/transaction/mod.rs
+++ b/crates/paymaster-starknet/src/transaction/mod.rs
@@ -11,7 +11,7 @@ mod call;
 pub use call::*;
 
 mod gas;
-pub use gas::TransactionGasEstimate;
+pub use gas::{TransactionGasEstimate, DEFAULT_MAX_L2_GAS_AMOUNT};
 use paymaster_common::enum_dispatch;
 
 mod time;


### PR DESCRIPTION
## Problem

Heavy **sponsored** transactions — e.g. a Garaga UltraHonk proof verification — are rejected **pre-broadcast** by the Starknet sequencer gateway:

```
Max gas amount is too high: GasAmount(1309915066), maximum allowed gas amount: 1200000000
```

(surfaced to clients as RPC code `156`), even though the transaction only consumes **~759M** L2 gas.

### Root cause

The declared `max_l2_gas` bound is the fee estimate padded by the **×1.5** gas multiplier (`gas.rs`). For a large but legitimate L2 workload this padded bound (~1.31B) exceeds the sequencer's **stateless** `max_l2_gas_amount` cap (`1_200_000_000` on mainnet, defined in `starkware-libs/sequencer` `apollo_gateway`), which validates the *declared* bound before broadcast — regardless of the much lower actual consumption.

The cap is the sequencer operator's (StarkWare); the only lever on our side is the value we declare.

## Fix

- **Cap the declared L2 gas bound** at a configurable `max_l2_gas_amount` (default **`1_200_000_000`** — exactly the mainnet sequencer limit): `min(estimate × 1.5, cap)`. The gateway check is strict (`l2_gas.max_amount > config.max_l2_gas_amount`), so declaring **exactly** the cap is accepted. L1 gas and L1 data gas keep their full ×1.5 padding — only L2 (the resource that hits the cap) is clamped.
- **Early reject** before locking a relayer and broadcasting when even the bare estimate (`×1.1` safety) cannot fit under the cap. This avoids a paid out-of-gas revert and returns a clear, typed error (**new RPC code `169` — `MAX_L2_GAS_AMOUNT_EXCEEDED`**) instead of the opaque `156`.
- **Configurable** via the `starknet` config block (`max_l2_gas_amount`, `#[serde(default)]`) so it can be tuned per network without a redeploy (the sequencer value may change). Existing profiles keep working unchanged.

### Why this is safe
- `min()` is a **no-op for any transaction that already fits** (`estimate × 1.5 ≤ cap`) → **no regression** on existing working traffic.
- It only changes behaviour for transactions that are **currently hard-rejected** (`156`) — turning them into either a success (when actual consumption fits) or a clean early reject (when it cannot). The only new cost surface is a paid revert for a transaction whose *real* consumption drifts above the cap; that is bounded by the early reject and minimized by the fresh re-estimate done right before send.

### Example (the failing case)
estimate ~873M → `min(1.31B, 1.2B) = 1.2B` declared (accepted: the gateway only rejects `> 1.2B`); early reject not triggered (`873M × 1.1 = 960M < 1.2B`); ~1.58× headroom over the 759M actual → **executes without revert**.

## Verification
- `cargo check --workspace --all-targets` ✅
- 5 new unit tests in `gas.rs` (padding below cap / clamp when padding exceeds cap / early reject / custom override / cap preserved through `update_overall_fee`) ✅
- `cargo clippy` — no new findings on the changed code ✅
- Adversarial multi-agent review of the diff (flow/threading, semantics/edge-cases, error mapping). The one confirmed finding — the typed error was being flattened to `156` by the relayer boundary — is fixed by running the cap check on the estimate path (before relayer locking), so code `169` reaches the client.

## Notes / possible follow-up
- The early-reject is wired into the `executeTransaction` path (where the `156` actually occurs). `buildTransaction` still returns a fee estimate without enforcing the cap; rejecting there too (so a client never signs a doomed tx) would be a small, separate enhancement.
- The default equals the mainnet `max_l2_gas_amount` exactly; since it is an operator-controlled value that can change, it is configurable per network via the `starknet` config block.
