### PR TITLE
Parse InvokeWithComputation server action in apply_actions calldata

### DIFF
--- a/crates/paymaster-starknet/src/transaction/call/server_action.rs
+++ b/crates/paymaster-starknet/src/transaction/call/server_action.rs
@@ -36,6 +36,8 @@ pub enum ServerAction {
     EmitNoteUsed { nullifier: Felt },
     /// Variant 10: Invoke { contract_address: ContractAddress, calldata: Span<felt252> }
     Invoke { contract_address: Felt, calldata: Vec<Felt> },
+    /// Variant 11: InvokeWithComputation { contract_address: ContractAddress, calldata: Span<felt252> }
+    InvokeWithComputation { contract_address: Felt, calldata: Vec<Felt> },
 }
 
 /// Error type for ServerAction parsing
@@ -190,6 +192,11 @@ fn parse_action(cursor: &mut Cursor) -> Result<ServerAction, ServerActionError> 
             let calldata = cursor.next_span()?;
             Ok(ServerAction::Invoke { contract_address, calldata })
         },
+        11 => {
+            let contract_address = cursor.next()?;
+            let calldata = cursor.next_span()?;
+            Ok(ServerAction::InvokeWithComputation { contract_address, calldata })
+        },
         _ => Err(ServerActionError::UnknownVariant(variant)),
     }
 }
@@ -311,6 +318,54 @@ mod tests {
                 calldata: vec![felt!("0xD"), felt!("0xE")],
             }
         );
+    }
+
+    #[test]
+    fn parse_invoke_with_computation_variable_length() {
+        let calldata = vec![
+            Felt::ONE,         // 1 action
+            Felt::from(11u64), // variant 11 = InvokeWithComputation
+            felt!("0x456"),    // contract_address
+            Felt::TWO,         // span length = 2
+            felt!("0xD"),
+            felt!("0xE"),
+        ];
+        let actions = parse_server_actions(&calldata).unwrap();
+        assert_eq!(actions.len(), 1);
+        assert_eq!(
+            actions[0],
+            ServerAction::InvokeWithComputation {
+                contract_address: felt!("0x456"),
+                calldata: vec![felt!("0xD"), felt!("0xE")],
+            }
+        );
+    }
+
+    /// A compute-and-invoke `apply_actions` span carries an `InvokeWithComputation` action
+    /// alongside the fee `TransferTo` that repays the relayer; both must decode so fee
+    /// discovery can locate the transfer.
+    #[test]
+    fn parse_invoke_with_computation_alongside_fee_transfer() {
+        let calldata = vec![
+            Felt::TWO, // 2 actions
+            // Action 0: InvokeWithComputation (variant 11)
+            Felt::from(11u64),
+            felt!("0x456"), // contract_address
+            Felt::ONE,      // span length = 1
+            felt!("0xD"),
+            // Action 1: TransferTo (variant 3) — fee to forwarder
+            Felt::THREE,
+            felt!("0xFEE"),     // to_addr (forwarder)
+            felt!("0x111"),     // token
+            Felt::from(100u64), // amount
+        ];
+        let actions = parse_server_actions(&calldata).unwrap();
+        assert_eq!(actions.len(), 2);
+        assert!(matches!(&actions[0], ServerAction::InvokeWithComputation { .. }));
+        assert!(matches!(
+            &actions[1],
+            ServerAction::TransferTo { to_addr, amount, .. } if *to_addr == felt!("0xFEE") && *amount == 100
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

For privacy-pool transactions the paymaster decodes the pool's `apply_actions` calldata to
locate the `TransferTo` that repays the relayer
(`ExecutableApplyActionParameters::find_gas_token_transfer` → `parse_server_actions`). The parser
in `paymaster-starknet` mirrors the pool contract's `ServerAction` enum, currently covering
discriminants `0..=10` (variant 10 = `Invoke`).

The privacy pool's **compute-and-invoke** flow (used by the sub-account / private-DeFi anonymizer)
emits a new server action, `InvokeWithComputation`, serialized as discriminant **11** in the
`apply_actions` action span. Because the parser has no arm for variant 11,
`parse_server_actions` returns `UnknownVariant(11)`, which surfaces as `Error::CalldataParsing`.
This rejects the transaction at build/estimate time — before a relayer is ever locked — so the
paymaster cannot sponsor compute-and-invoke transactions in any fee mode where the pool fee is
collected.

## Fix

Add `InvokeWithComputation` (variant 11) to the `ServerAction` mirror and a matching arm in
`parse_action`. It carries the same `InvokeInput` payload as `Invoke` — `contract_address` plus a
`calldata` span — and the paymaster only parses the span to locate the fee `TransferTo` (the
`apply_actions` calldata is relayed verbatim). Nothing else needs to change: fee discovery,
estimation, and execution are unaffected once the action decodes.

## Tests

- `parse_invoke_with_computation_variable_length` — decodes the new variant in isolation.
- `parse_invoke_with_computation_alongside_fee_transfer` — decodes a realistic `apply_actions`
  span where the `InvokeWithComputation` action precedes the fee `TransferTo`, confirming fee
  discovery can still locate the transfer.

`cargo test -p paymaster-starknet` → 19 passed, 0 failed. `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
